### PR TITLE
CIV-1290 Throw Exception if solicitor is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
@@ -89,14 +89,18 @@ public class AssignCaseToUserCallbackHandler extends CallbackHandler {
         Optional<Organisation> org = findOrganisation(callbackParams.getParams().get(BEARER_TOKEN).toString());
 
         List<CaseAssignedUserRole> applicantSolicitors = userRoles.getCaseAssignedUserRoles().stream()
-            .filter(CA -> CA.getCaseRole().contentEquals(CaseRole.APPLICANTSOLICITORONE.toString())
-                || CA.getCaseRole().contentEquals(CaseRole.APPLICANTSOLICITORTWO.toString()))
+            .filter(CA -> CA.getCaseRole().contentEquals(CaseRole.APPLICANTSOLICITORONE.getFormattedName())
+                || CA.getCaseRole().contentEquals(CaseRole.APPLICANTSOLICITORTWO.getFormattedName()))
             .collect(Collectors.toList());
 
         List<CaseAssignedUserRole> respondentSolicitors = userRoles.getCaseAssignedUserRoles().stream()
-            .filter(CA -> CA.getCaseRole().contentEquals(CaseRole.RESPONDENTSOLICITORONE.toString())
-                || CA.getCaseRole().contentEquals(CaseRole.RESPONDENTSOLICITORTWO.toString()))
+            .filter(CA -> CA.getCaseRole().contentEquals(CaseRole.RESPONDENTSOLICITORONE.getFormattedName())
+                || CA.getCaseRole().contentEquals(CaseRole.RESPONDENTSOLICITORTWO.getFormattedName()))
             .collect(Collectors.toList());
+
+        if (applicantSolicitors.isEmpty() && respondentSolicitors.isEmpty()) {
+            throw new IllegalArgumentException("Applicant and Respondent Solicitors should not be Null");
+        }
 
         if (org.isPresent()) {
             String organisationId = org.get().getOrganisationIdentifier();

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/caseassignment/AssignCaseToUserHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/caseassignment/AssignCaseToUserHandlerTest.java
@@ -29,10 +29,12 @@ import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplication;
 import uk.gov.hmcts.reform.civil.service.CoreCaseUserService;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -109,15 +111,15 @@ public class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
     public List<CaseAssignedUserRole> getCaseAssignedApplicantUserRoles() {
         List<CaseAssignedUserRole> caseAssignedUserRoles = List.of(
             CaseAssignedUserRole.builder().caseDataId("1").userId("1")
-                .caseRole(CaseRole.APPLICANTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.APPLICANTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("f5e5cc53-e065-43dd-8cec-2ad005a6b9a9")
-                .caseRole(CaseRole.APPLICANTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.APPLICANTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("3")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("4")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("5")
-                .caseRole(CaseRole.APPLICANTSOLICITORONE.toString()).build());
+                .caseRole(CaseRole.APPLICANTSOLICITORONE.getFormattedName()).build());
 
         return caseAssignedUserRoles;
     }
@@ -125,13 +127,13 @@ public class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
     public List<CaseAssignedUserRole> getCaseAssignedRespondentUserRoles() {
         List<CaseAssignedUserRole> caseAssignedUserRoles = List.of(
             CaseAssignedUserRole.builder().caseDataId("1").userId("f5e5cc53-e065-43dd-8cec-2ad005a6b9a9")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("3")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("4")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("5")
-                .caseRole(CaseRole.APPLICANTSOLICITORONE.toString()).build());
+                .caseRole(CaseRole.APPLICANTSOLICITORONE.getFormattedName()).build());
 
         return caseAssignedUserRoles;
     }
@@ -139,14 +141,19 @@ public class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
     public List<CaseAssignedUserRole> getCaseAssignedRespondentUserRolesWithNoApplicantSolicitor() {
         List<CaseAssignedUserRole> caseAssignedUserRoles = List.of(
             CaseAssignedUserRole.builder().caseDataId("1").userId("f5e5cc53-e065-43dd-8cec-2ad005a6b9a9")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("3")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("4")
-                .caseRole(CaseRole.RESPONDENTSOLICITORONE.toString()).build(),
+                .caseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()).build(),
             CaseAssignedUserRole.builder().caseDataId("1").userId("5")
-                .caseRole(CaseRole.RESPONDENTSOLICITORTWO.toString()).build());
+                .caseRole(CaseRole.RESPONDENTSOLICITORTWO.getFormattedName()).build());
 
+        return caseAssignedUserRoles;
+    }
+
+    public List<CaseAssignedUserRole> getCaseAssignedApplicantUserRolesEmptyList() {
+        List<CaseAssignedUserRole> caseAssignedUserRoles = Collections.emptyList();
         return caseAssignedUserRoles;
     }
 
@@ -168,6 +175,20 @@ public class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
             "OrgId1",
             CaseRole.APPLICANTSOLICITORONE
         );
+    }
+
+    @Test
+    void shouldThrowExceptionForNoSolicitors() {
+
+        when(caseAccessDataStoreApi.getUserRoles(any(), any(), any()))
+            .thenReturn(CaseAssignedUserRolesResource.builder()
+                            .caseAssignedUserRoles(getCaseAssignedApplicantUserRolesEmptyList()).build());
+        when(organisationApi.findUserOrganisation(any(), any()))
+            .thenReturn(uk.gov.hmcts.reform.prd.model.Organisation
+                            .builder().organisationIdentifier("OrgId1").build());
+
+        assertThrows(IllegalArgumentException.class, () ->
+            assignCaseToUserHandler.handle(params));
     }
 
     @Test


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-1290

### Change description ###

Assign Roles to Applicant and Respondent GA 

### README ###
1. Get the User Details from Auth token of the user who has initiated the GA (InitiateGA)
2. Get All the users using the GET API and separate out the applicant and respondent sols 
3. Match the user ID from step 1 and step 2
4. If the match is on applicant solicitor list then assign the GA case to all the solicitors in that list as App Solicitor and the other list as respondent sols
5. If the match is on the respondent solicitor list then assign the GA case to all the respondents sols in that list as App solicitor and the other list as Respondent solicitor

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
