### PR TITLE
CIV-316 Populate Applicant and respondant Solicitors

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/model/SolicitorDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/model/SolicitorDetails.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.ccd.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder(toBuilder = true)
+public class SolicitorDetails {
+
+    @JsonProperty("caseDataId")
+    private String caseDataId;
+
+    @JsonProperty("userId")
+    private String userId;
+
+    @JsonProperty("caseRole")
+    private String caseRole;
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/CallbackHandlerHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/CallbackHandlerHelper.java
@@ -26,7 +26,6 @@ public class CallbackHandlerHelper {
 
     private static final String GENERAL_APPLICATIONS_DETAILS = "generalApplicationsDetails";
 
-
     public void updateParentWithGAState(CaseData generalAppCaseData, String newState) {
         String applicationId = generalAppCaseData.getCcdCaseReference().toString();
         String parentCaseId = generalAppCaseData.getGeneralAppParentCaseLink().getCaseReference();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/CallbackHandlerHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/CallbackHandlerHelper.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.civil.handler.callback;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplicationsDetails;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.util.CollectionUtils.isEmpty;
+import static uk.gov.hmcts.reform.civil.callback.CaseEvent.UPDATE_CASE_WITH_GA_STATE;
+
+@Service
+@RequiredArgsConstructor
+public class CallbackHandlerHelper {
+
+    private final CaseDetailsConverter caseDetailsConverter;
+    private final CoreCaseDataService coreCaseDataService;
+    private final ObjectMapper mapper;
+
+    private static final String GENERAL_APPLICATIONS_DETAILS = "generalApplicationsDetails";
+
+
+    public void updateParentWithGAState(CaseData generalAppCaseData, String newState) {
+        String applicationId = generalAppCaseData.getCcdCaseReference().toString();
+        String parentCaseId = generalAppCaseData.getGeneralAppParentCaseLink().getCaseReference();
+
+        StartEventResponse startEventResponse = coreCaseDataService.startUpdate(parentCaseId,
+                                                                                UPDATE_CASE_WITH_GA_STATE);
+        CaseData caseData = caseDetailsConverter.toCaseData(startEventResponse.getCaseDetails());
+
+        List<Element<GeneralApplicationsDetails>> generalApplications = caseData.getGeneralApplicationsDetails();
+        if (!isEmpty(generalApplications)) {
+            generalApplications.stream()
+                .filter(application -> applicationFilterCriteria(application, applicationId))
+                .findAny()
+                .orElseThrow(IllegalArgumentException::new)
+                .getValue().setCaseState(newState);
+            coreCaseDataService.submitUpdate(parentCaseId, coreCaseDataService.caseDataContentFromStartEventResponse(
+                startEventResponse, getUpdatedCaseData(caseData, generalApplications)));
+        }
+    }
+
+    private boolean applicationFilterCriteria(Element<GeneralApplicationsDetails> gaDetails, String applicationId) {
+        return gaDetails.getValue() != null
+            && gaDetails.getValue().getCaseLink() != null
+            && applicationId.equals(gaDetails.getValue().getCaseLink().getCaseReference());
+    }
+
+    private Map<String, Object> getUpdatedCaseData(CaseData caseData,
+                                                   List<Element<GeneralApplicationsDetails>>
+                                                       generalApplicationsDetails) {
+        Map<String, Object> output = caseData.toMap(mapper);
+        output.put(GENERAL_APPLICATIONS_DETAILS, generalApplicationsDetails);
+        return output;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
@@ -1,33 +1,26 @@
 package uk.gov.hmcts.reform.civil.handler.callback.camunda.businessprocess;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
-import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.Callback;
 import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
-import uk.gov.hmcts.reform.civil.model.common.Element;
-import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplicationsDetails;
-import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.END_BUSINESS_PROCESS_GASPEC;
-import static uk.gov.hmcts.reform.civil.callback.CaseEvent.UPDATE_CASE_WITH_GA_STATE;
 import static uk.gov.hmcts.reform.civil.enums.CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION;
 import static uk.gov.hmcts.reform.civil.enums.CaseState.AWAITING_RESPONDENT_RESPONSE;
 import static uk.gov.hmcts.reform.civil.utils.ApplicationNotificationUtil.isNotificationCriteriaSatisfied;
-import static uk.gov.hmcts.reform.civil.utils.RespondentsResponsesUtil.isRespondentsResponesSatisfied;
 
 @Service
 @RequiredArgsConstructor
@@ -36,10 +29,7 @@ public class EndGeneralAppBusinessProcessCallbackHandler extends CallbackHandler
     private static final List<CaseEvent> EVENTS = List.of(END_BUSINESS_PROCESS_GASPEC);
 
     private final CaseDetailsConverter caseDetailsConverter;
-    private final CoreCaseDataService coreCaseDataService;
-    private final ObjectMapper mapper;
-
-    private static final String GENERAL_APPLICATIONS_DETAILS = "generalApplicationsDetails";
+    private final CallbackHandlerHelper callbackHandlerHelper;
 
     @Override
     protected Map<String, Callback> callbacks() {
@@ -56,7 +46,7 @@ public class EndGeneralAppBusinessProcessCallbackHandler extends CallbackHandler
         CaseState newState = isNotificationCriteriaSatisfied(data)
                 ? AWAITING_RESPONDENT_RESPONSE
                 : APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION;
-        updateParentWithGAState(data, newState.getDisplayedValue());
+        callbackHandlerHelper.updateParentWithGAState(data, newState.getDisplayedValue());
         return evaluateReady(callbackParams, newState);
     }
 
@@ -69,39 +59,4 @@ public class EndGeneralAppBusinessProcessCallbackHandler extends CallbackHandler
                 .data(output)
                 .build();
     }
-
-    private void updateParentWithGAState(CaseData generalAppCaseData, String newState) {
-        String applicationId = generalAppCaseData.getCcdCaseReference().toString();
-        String parentCaseId = generalAppCaseData.getGeneralAppParentCaseLink().getCaseReference();
-
-        StartEventResponse startEventResponse = coreCaseDataService.startUpdate(parentCaseId,
-                UPDATE_CASE_WITH_GA_STATE);
-        CaseData caseData = caseDetailsConverter.toCaseData(startEventResponse.getCaseDetails());
-
-        List<Element<GeneralApplicationsDetails>> generalApplications = caseData.getGeneralApplicationsDetails();
-        if (!isEmpty(generalApplications)) {
-            generalApplications.stream()
-                    .filter(application -> applicationFilterCriteria(application, applicationId))
-                    .findAny()
-                    .orElseThrow(IllegalArgumentException::new)
-                    .getValue().setCaseState(newState);
-            coreCaseDataService.submitUpdate(parentCaseId, coreCaseDataService.caseDataContentFromStartEventResponse(
-                    startEventResponse, getUpdatedCaseData(caseData, generalApplications)));
-        }
-    }
-
-    private boolean applicationFilterCriteria(Element<GeneralApplicationsDetails> gaDetails, String applicationId) {
-        return gaDetails.getValue() != null
-                && gaDetails.getValue().getCaseLink() != null
-                && applicationId.equals(gaDetails.getValue().getCaseLink().getCaseReference());
-    }
-
-    private Map<String, Object> getUpdatedCaseData(CaseData caseData,
-                                                   List<Element<GeneralApplicationsDetails>>
-                                                           generalApplicationsDetails) {
-        Map<String, Object> output = caseData.toMap(mapper);
-        output.put(GENERAL_APPLICATIONS_DETAILS, generalApplicationsDetails);
-        return output;
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
@@ -9,9 +9,9 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
-import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.ParentCaseUpdateHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +29,7 @@ public class EndGeneralAppBusinessProcessCallbackHandler extends CallbackHandler
     private static final List<CaseEvent> EVENTS = List.of(END_BUSINESS_PROCESS_GASPEC);
 
     private final CaseDetailsConverter caseDetailsConverter;
-    private final CallbackHandlerHelper callbackHandlerHelper;
+    private final ParentCaseUpdateHelper parentCaseUpdateHelper;
 
     @Override
     protected Map<String, Callback> callbacks() {
@@ -46,7 +46,7 @@ public class EndGeneralAppBusinessProcessCallbackHandler extends CallbackHandler
         CaseState newState = isNotificationCriteriaSatisfied(data)
                 ? AWAITING_RESPONDENT_RESPONSE
                 : APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION;
-        callbackHandlerHelper.updateParentWithGAState(data, newState.getDisplayedValue());
+        parentCaseUpdateHelper.updateParentWithGAState(data, newState.getDisplayedValue());
         return evaluateReady(callbackParams, newState);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandler.java
@@ -27,6 +27,7 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.UPDATE_CASE_WITH_GA_S
 import static uk.gov.hmcts.reform.civil.enums.CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION;
 import static uk.gov.hmcts.reform.civil.enums.CaseState.AWAITING_RESPONDENT_RESPONSE;
 import static uk.gov.hmcts.reform.civil.utils.ApplicationNotificationUtil.isNotificationCriteriaSatisfied;
+import static uk.gov.hmcts.reform.civil.utils.RespondentsResponsesUtil.isRespondentsResponesSatisfied;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
@@ -110,7 +110,7 @@ public class AssignCaseToUserCallbackHandler extends CallbackHandler {
         if (org.isPresent()) {
             String organisationId = org.get().getOrganisationIdentifier();
             List<Element<SolicitorDetails>> applicantSols = new ArrayList<>();
-            List<Element<SolicitorDetails>> respondantSols = new ArrayList<>();
+            List<Element<SolicitorDetails>> respondentSols = new ArrayList<>();
 
             if (!applicantSolicitors.isEmpty() && applicantSolicitors.stream().anyMatch(AS -> AS.getUserId().equals(
                 submitterId))) {
@@ -128,13 +128,13 @@ public class AssignCaseToUserCallbackHandler extends CallbackHandler {
                 respondentSolicitors.stream().forEach((RS) -> {
                     coreCaseUserService
                         .assignCase(caseId, RS.getUserId(), organisationId, CaseRole.RESPONDENTSOLICITORONE);
-                    respondantSols.add(element(SolicitorDetails.builder().caseRole(RS.getCaseRole())
+                    respondentSols.add(element(SolicitorDetails.builder().caseRole(RS.getCaseRole())
                                                   .caseDataId(RS.getCaseDataId())
                                                   .userId(RS.getUserId()).build()));
                 });
 
                 caseDataBuilder.applicantSolicitors(applicantSols);
-                caseDataBuilder.defendantSolicitors(respondantSols);
+                caseDataBuilder.defendantSolicitors(respondentSols);
 
             } else if (!respondentSolicitors.isEmpty() && respondentSolicitors.stream()
                 .anyMatch(AS -> AS.getUserId().equals(submitterId))) {
@@ -144,7 +144,7 @@ public class AssignCaseToUserCallbackHandler extends CallbackHandler {
                 applicantSolicitors.stream().forEach((RS) -> {
                     coreCaseUserService
                         .assignCase(caseId, RS.getUserId(), organisationId, CaseRole.RESPONDENTSOLICITORONE);
-                    respondantSols.add(element(SolicitorDetails.builder().caseRole(RS.getCaseRole())
+                    respondentSols.add(element(SolicitorDetails.builder().caseRole(RS.getCaseRole())
                                                    .caseDataId(RS.getCaseDataId())
                                                    .userId(RS.getUserId()).build()));
                 });

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
@@ -195,7 +195,8 @@ public class RespondToApplicationHandler extends CallbackHandler {
         CaseData caseData = caseDetailsConverter.toCaseData(callbackParams.getRequest().getCaseDetails());
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
 
-        List<Element<GARespondentResponse>> respondentsResponses = addApplication(buildApplication(caseData), caseData.getRespondentsResponses());
+        List<Element<GARespondentResponse>> respondentsResponses =
+            addApplication(buildApplication(caseData), caseData.getRespondentsResponses());
 
         caseDataBuilder.respondentsResponses(respondentsResponses);
 
@@ -224,7 +225,8 @@ public class RespondToApplicationHandler extends CallbackHandler {
 
         GARespondentResponse.GARespondentResponseBuilder gaRespondentResponseBuilder = GARespondentResponse.builder();
 
-        gaRespondentResponseBuilder.generalAppRespondent1Representative(caseData.getGeneralAppRespondent1Representative()
+        gaRespondentResponseBuilder
+            .generalAppRespondent1Representative(caseData.getGeneralAppRespondent1Representative()
                                                             .getGeneralAppRespondent1Representative())
             .gaHearingDetails(caseData.getHearingDetailsResp()).build();
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
@@ -12,13 +12,13 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
-import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAHearingDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUnavailabilityDates;
+import uk.gov.hmcts.reform.civil.service.ParentCaseUpdateHelper;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class RespondToApplicationHandler extends CallbackHandler {
 
     private final ObjectMapper objectMapper;
     private final CaseDetailsConverter caseDetailsConverter;
-    private final CallbackHandlerHelper callbackHandlerHelper;
+    private final ParentCaseUpdateHelper parentCaseUpdateHelper;
 
     private static final String RESPONSE_MESSAGE = "# You have responded to an application";
     private static final String JUDGES_REVIEW_MESSAGE =
@@ -203,7 +203,7 @@ public class RespondToApplicationHandler extends CallbackHandler {
         CaseState newState = isRespondentsResponseSatisfied(caseData, caseDataBuilder)
             ? APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION
             : AWAITING_RESPONDENT_RESPONSE;
-        callbackHandlerHelper.updateParentWithGAState(caseData, newState.getDisplayedValue());
+        parentCaseUpdateHelper.updateParentWithGAState(caseData, newState.getDisplayedValue());
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .state(newState.toString())

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.handler.callback.user;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
@@ -11,9 +12,11 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAHearingDetails;
+import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUnavailabilityDates;
 
 import java.time.LocalDate;
@@ -23,18 +26,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.RESPOND_TO_APPLICATION;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
 
 @SuppressWarnings({"checkstyle:Indentation", "checkstyle:EmptyLineSeparator"})
 @Service
 @RequiredArgsConstructor
 public class RespondToApplicationHandler extends CallbackHandler {
+
+    private final ObjectMapper objectMapper;
+    private final CaseDetailsConverter caseDetailsConverter;
 
     private static final String RESPONSE_MESSAGE = "# You have responded to an application";
     private static final String JUDGES_REVIEW_MESSAGE =
@@ -64,6 +74,7 @@ public class RespondToApplicationHandler extends CallbackHandler {
         return Map.of(
             callbackKey(ABOUT_TO_START), this::isApplicationInJudicialReviewStage,
             callbackKey(MID, "hearing-screen-response"), this::hearingScreenResponse,
+            callbackKey(ABOUT_TO_SUBMIT), this::submitClaim,
             callbackKey(SUBMITTED), this::buildResponseConfirmation
         );
     }
@@ -172,5 +183,40 @@ public class RespondToApplicationHandler extends CallbackHandler {
             appType,
             JUDGES_REVIEW_MESSAGE
         );
+    }
+
+    private CallbackResponse submitClaim(CallbackParams callbackParams) {
+
+        CaseData caseData = caseDetailsConverter.toCaseData(callbackParams.getRequest().getCaseDetails());
+        CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
+
+        List<Element<GARespondentResponse>> respondentsResponses = addApplication(buildApplication(caseData), caseData.getRespondentsResponses());
+
+        caseDataBuilder.respondentsResponses(respondentsResponses);
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .data(caseDataBuilder.build().toMap(objectMapper))
+            .build();
+    }
+
+    private List<Element<GARespondentResponse>> addApplication(GARespondentResponse gaRespondentResponseBuilder,
+                                                             List<Element<GARespondentResponse>> respondentsResponses) {
+
+        List<Element<GARespondentResponse>> newApplication = ofNullable(respondentsResponses).orElse(newArrayList());
+        newApplication.add(element(gaRespondentResponseBuilder));
+
+        return newApplication;
+    }
+
+
+    private GARespondentResponse buildApplication(CaseData caseData) {
+
+        GARespondentResponse.GARespondentResponseBuilder gaRespondentResponseBuilder = GARespondentResponse.builder();
+
+        gaRespondentResponseBuilder.hasRespondentAgreed(caseData.getGeneralAppRespondent1Representative()
+                                                            .getGeneralAppRespondent1Representative())
+            .gaHearingDetails(caseData.getHearingDetailsResp()).build();
+
+        return gaRespondentResponseBuilder.build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.civil.model.genapplication.GAInformOtherParty;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAJudicialDecision;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAPbaDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentOrderAgreement;
+import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAStatementOfTruth;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUrgencyRequirement;
 import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplication;
@@ -65,6 +66,7 @@ public class CaseData implements MappableObject {
     private final GAJudicialDecision judicialDecision;
     private final List<Element<SolicitorDetails>> applicantSolicitors;
     private final List<Element<SolicitorDetails>> defendantSolicitors;
+    private final List<Element<GARespondentResponse>> respondentsResponses;
 
     private final BusinessProcess businessProcess;
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
+import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.common.Element;
@@ -60,6 +61,8 @@ public class CaseData implements MappableObject {
     private final List<Element<Document>> generalAppEvidenceDocument;
     private final List<Element<GeneralApplication>> generalApplications;
     private final List<Element<GeneralApplicationsDetails>> generalApplicationsDetails;
+    private final List<Element<SolicitorDetails>> applicantSolicitors;
+    private final List<Element<SolicitorDetails>> defendantSolicitors;
 
     private final BusinessProcess businessProcess;
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/GARespondentRepresentative.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/GARespondentRepresentative.java
@@ -15,7 +15,7 @@ public class GARespondentRepresentative {
     private final YesOrNo generalAppRespondent1Representative;
 
     @JsonCreator
-    GARespondentRepresentative(@JsonProperty("generalAppRespondent1Representative")
+    GARespondentRepresentative(@JsonProperty("hasAgreed")
                                    YesOrNo generalAppRespondent1Representative) {
         this.generalAppRespondent1Representative = generalAppRespondent1Representative;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GARespondentResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GARespondentResponse.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.civil.model.genapplication;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
+import uk.gov.hmcts.reform.civil.model.common.MappableObject;
+
+@Data
+@Builder(toBuilder = true)
+public class GARespondentResponse implements MappableObject {
+
+    private GAHearingDetails gaHearingDetails;
+    private final YesOrNo hasRespondentAgreed;
+
+    @JsonCreator
+    GARespondentResponse(@JsonProperty("gaHearingDetails") GAHearingDetails gaHearingDetails,
+                         @JsonProperty("hasRespondentAgreed")
+                             YesOrNo hasRespondentAgreed) {
+        this.gaHearingDetails = gaHearingDetails;
+        this.hasRespondentAgreed = hasRespondentAgreed;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GARespondentResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GARespondentResponse.java
@@ -12,13 +12,13 @@ import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 public class GARespondentResponse implements MappableObject {
 
     private GAHearingDetails gaHearingDetails;
-    private final YesOrNo hasRespondentAgreed;
+    private final YesOrNo generalAppRespondent1Representative;
 
     @JsonCreator
     GARespondentResponse(@JsonProperty("gaHearingDetails") GAHearingDetails gaHearingDetails,
-                         @JsonProperty("hasRespondentAgreed")
-                             YesOrNo hasRespondentAgreed) {
+                         @JsonProperty("generalAppRespondent1Representative")
+                             YesOrNo generalAppRespondent1Representative) {
         this.gaHearingDetails = gaHearingDetails;
-        this.hasRespondentAgreed = hasRespondentAgreed;
+        this.generalAppRespondent1Representative = generalAppRespondent1Representative;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
+import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseLink;
@@ -44,6 +45,8 @@ public class GeneralApplication implements MappableObject {
     private GeneralAppParentCaseLink generalAppParentCaseLink;
     private final IdamUserDetails civilServiceUserRoles;
     private LocalDateTime generalAppSubmittedDateGAspec;
+    private final List<Element<SolicitorDetails>> applicantSolicitors;
+    private final List<Element<SolicitorDetails>> defendantSolicitors;
 
     @JsonCreator
     GeneralApplication(@JsonProperty("generalAppType") GAApplicationType generalAppType,
@@ -68,7 +71,9 @@ public class GeneralApplication implements MappableObject {
                        @JsonProperty("caseLink") CaseLink caseLink,
                        @JsonProperty("generalAppParentCaseLink") GeneralAppParentCaseLink generalAppParentCaseLink,
                        @JsonProperty("civilServiceUserRoles") IdamUserDetails civilServiceUserRoles,
-                       @JsonProperty("generalAppSubmittedDateGAspec") LocalDateTime generalAppSubmittedDateGAspec) {
+                       @JsonProperty("generalAppSubmittedDateGAspec") LocalDateTime generalAppSubmittedDateGAspec,
+                       @JsonProperty("applicantSolicitors") List<Element<SolicitorDetails>> applicantSolicitors,
+                       @JsonProperty("defendantSolicitors") List<Element<SolicitorDetails>> defendantSolicitors) {
         this.generalAppType = generalAppType;
         this.generalAppRespondentAgreement = generalAppRespondentAgreement;
         this.businessProcess = businessProcess;
@@ -91,6 +96,8 @@ public class GeneralApplication implements MappableObject {
         this.generalAppParentCaseLink = generalAppParentCaseLink;
         this.civilServiceUserRoles = civilServiceUserRoles;
         this.generalAppSubmittedDateGAspec = generalAppSubmittedDateGAspec;
+        this.applicantSolicitors = applicantSolicitors;
+        this.defendantSolicitors = defendantSolicitors;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
@@ -44,6 +44,7 @@ public class GeneralApplication implements MappableObject {
     private LocalDateTime generalAppSubmittedDateGAspec;
     private final List<Element<SolicitorDetails>> applicantSolicitors;
     private final List<Element<SolicitorDetails>> defendantSolicitors;
+    private final List<Element<GARespondentResponse>> respondentsResponses;
 
     @JsonCreator
     GeneralApplication(@JsonProperty("generalAppType") GAApplicationType generalAppType,
@@ -67,7 +68,8 @@ public class GeneralApplication implements MappableObject {
                        @JsonProperty("civilServiceUserRoles") IdamUserDetails civilServiceUserRoles,
                        @JsonProperty("generalAppSubmittedDateGAspec") LocalDateTime generalAppSubmittedDateGAspec,
                        @JsonProperty("applicantSolicitors") List<Element<SolicitorDetails>> applicantSolicitors,
-                       @JsonProperty("defendantSolicitors") List<Element<SolicitorDetails>> defendantSolicitors) {
+                       @JsonProperty("defendantSolicitors") List<Element<SolicitorDetails>> defendantSolicitors,
+                       @JsonProperty("respondentsResponses") List<Element<GARespondentResponse>> respondentsResponses) {
         this.generalAppType = generalAppType;
         this.generalAppRespondentAgreement = generalAppRespondentAgreement;
         this.businessProcess = businessProcess;
@@ -89,6 +91,7 @@ public class GeneralApplication implements MappableObject {
         this.generalAppSubmittedDateGAspec = generalAppSubmittedDateGAspec;
         this.applicantSolicitors = applicantSolicitors;
         this.defendantSolicitors = defendantSolicitors;
+        this.respondentsResponses = respondentsResponses;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
-import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
 import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/ParentCaseUpdateHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/ParentCaseUpdateHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.civil.handler.callback;
+package uk.gov.hmcts.reform.civil.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +8,6 @@ import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplicationsDetails;
-import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
 import java.util.List;
 import java.util.Map;
@@ -18,7 +17,7 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.UPDATE_CASE_WITH_GA_S
 
 @Service
 @RequiredArgsConstructor
-public class CallbackHandlerHelper {
+public class ParentCaseUpdateHelper {
 
     private final CaseDetailsConverter caseDetailsConverter;
     private final CoreCaseDataService coreCaseDataService;

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
@@ -12,9 +12,11 @@ public class RespondentsResponsesUtil {
     private static final int ONE_V_ONE = 1;
     private static final int ONE_V_TWO = 2;
 
+    private RespondentsResponsesUtil() {
+        // Utilities class, no instances
+    }
 
-    public static boolean isRespondentsResponseSatisfied(CaseData caseData
-        , CaseData.CaseDataBuilder caseDataBuilder) {
+    public static boolean isRespondentsResponseSatisfied(CaseData caseData, CaseData.CaseDataBuilder caseDataBuilder) {
 
         if (caseData.getDefendantSolicitors() == null
             || caseDataBuilder.build().getRespondentsResponses() == null) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
@@ -3,19 +3,37 @@ package uk.gov.hmcts.reform.civil.utils;
 import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 
 import java.util.List;
 
 public class RespondentsResponsesUtil {
 
-    public static boolean isRespondentsResponesSatisfied(CaseData caseData) {
+    private static final int ONE_V_ONE = 1;
+    private static final int ONE_V_TWO = 2;
 
-        // check multiple solicitors and check if all the solicitors has response the application
-        // if one solictor has response and another not return False
-        // if both solicitor has responsed or timer elpase, return True
+
+    public static boolean isRespondentsResponseSatisfied(CaseData caseData
+        , CaseData.CaseDataBuilder caseDataBuilder) {
+
+        if (caseData.getDefendantSolicitors() == null
+            || caseDataBuilder.build().getRespondentsResponses() == null) {
+            return false;
+        }
+
+        List<Element<GARespondentResponse>> respondentsResponses = caseDataBuilder.build().getRespondentsResponses();
         List<Element<SolicitorDetails>> defendantSolicitors = caseData.getDefendantSolicitors();
 
+        if (defendantSolicitors.size() == ONE_V_ONE
+            && respondentsResponses != null && respondentsResponses.size() == ONE_V_ONE) {
+            return true;
+        }
 
-        return true;
+        if (defendantSolicitors.size() == ONE_V_TWO && respondentsResponses != null) {
+            return respondentsResponses.size() == ONE_V_TWO;
+        }
+
+        return false;
+
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/RespondentsResponsesUtil.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+
+import java.util.List;
+
+public class RespondentsResponsesUtil {
+
+    public static boolean isRespondentsResponesSatisfied(CaseData caseData) {
+
+        // check multiple solicitors and check if all the solicitors has response the application
+        // if one solictor has response and another not return False
+        // if both solicitor has responsed or timer elpase, return True
+        List<Element<SolicitorDetails>> defendantSolicitors = caseData.getDefendantSolicitors();
+
+
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
+import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.CaseLink;
@@ -57,6 +58,7 @@ import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
     EndGeneralAppBusinessProcessCallbackHandler.class,
     CaseDetailsConverter.class,
     CoreCaseDataService.class,
+    CallbackHandlerHelper.class,
     ObjectMapper.class,
     ApplicationNotificationUtil.class
 })
@@ -67,6 +69,9 @@ public class EndGeneralAppBusinessProcessCallbackHandlerTest extends BaseCallbac
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private CallbackHandlerHelper callbackHandlerHelper;
 
     @MockBean
     private CaseDetailsConverter caseDetailsConverter;

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/businessprocess/EndGeneralAppBusinessProcessCallbackHandlerTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
-import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.CaseLink;
@@ -32,6 +31,7 @@ import uk.gov.hmcts.reform.civil.model.genapplication.GeneralApplicationsDetails
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+import uk.gov.hmcts.reform.civil.service.ParentCaseUpdateHelper;
 import uk.gov.hmcts.reform.civil.utils.ApplicationNotificationUtil;
 
 import java.util.HashMap;
@@ -58,7 +58,7 @@ import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
     EndGeneralAppBusinessProcessCallbackHandler.class,
     CaseDetailsConverter.class,
     CoreCaseDataService.class,
-    CallbackHandlerHelper.class,
+    ParentCaseUpdateHelper.class,
     ObjectMapper.class,
     ApplicationNotificationUtil.class
 })
@@ -71,7 +71,7 @@ public class EndGeneralAppBusinessProcessCallbackHandlerTest extends BaseCallbac
     private ObjectMapper objectMapper;
 
     @Autowired
-    private CallbackHandlerHelper callbackHandlerHelper;
+    private ParentCaseUpdateHelper parentCaseUpdateHelper;
 
     @MockBean
     private CaseDetailsConverter caseDetailsConverter;

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandlerTest.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.enums.dq.GeneralApplicationTypes;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
-import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
@@ -28,6 +27,7 @@ import uk.gov.hmcts.reform.civil.model.genapplication.GAApplicationType;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAHearingDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUnavailabilityDates;
+import uk.gov.hmcts.reform.civil.service.ParentCaseUpdateHelper;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ public class RespondToApplicationHandlerTest extends BaseCallbackHandlerTest {
     CaseDetailsConverter caseDetailsConverter;
 
     @MockBean
-    CallbackHandlerHelper callbackHandlerHelper;
+    ParentCaseUpdateHelper parentCaseUpdateHelper;
 
     List<Element<SolicitorDetails>> respondentSols = new ArrayList<>();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandlerTest.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.civil.handler.callback.user;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+import uk.gov.hmcts.reform.ccd.model.SolicitorDetails;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CallbackType;
 import uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus;
@@ -14,25 +18,32 @@ import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.enums.dq.GeneralApplicationTypes;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
+import uk.gov.hmcts.reform.civil.handler.callback.CallbackHandlerHelper;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.GARespondentRepresentative;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAApplicationType;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAHearingDetails;
+import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentResponse;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUnavailabilityDates;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.RESPOND_TO_APPLICATION;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
 @SuppressWarnings({"checkstyle:EmptyLineSeparator", "checkstyle:Indentation"})
 @SpringBootTest(classes = {
+    CaseDetailsConverter.class,
     RespondToApplicationHandler.class,
     JacksonAutoConfiguration.class,
 },
@@ -41,6 +52,19 @@ public class RespondToApplicationHandlerTest extends BaseCallbackHandlerTest {
 
     @Autowired
     RespondToApplicationHandler handler;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    CaseDetailsConverter caseDetailsConverter;
+
+    @MockBean
+    CallbackHandlerHelper callbackHandlerHelper;
+
+    List<Element<SolicitorDetails>> respondentSols = new ArrayList<>();
+
+    List<Element<GARespondentResponse>> respondentsResponses = new ArrayList<>();
 
     private static final String CAMUNDA_EVENT = "INITIATE_GENERAL_APPLICATION";
     private static final String BUSINESS_PROCESS_INSTANCE_ID = "11111";
@@ -245,6 +269,95 @@ public class RespondToApplicationHandlerTest extends BaseCallbackHandlerTest {
         }
     }
 
+    @Test
+    void shouldReturn_Awaiting_Respondent_Response_1Def_2Responses() {
+
+        respondentSols.add(element(SolicitorDetails.builder().caseRole("role").build()));
+        respondentsResponses.add(element(GARespondentResponse.builder().generalAppRespondent1Representative(YES).build()
+        ));
+
+        CaseData caseData = getCase(respondentSols, respondentsResponses);
+
+        Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+        });
+        CallbackParams params = callbackParamsOf(dataMap, CallbackType.ABOUT_TO_SUBMIT);
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response).isNotNull();
+        assertThat(response.getState()).isEqualTo("AWAITING_RESPONDENT_RESPONSE");
+    }
+
+    @Test
+    void shouldReturn_Application_Submitted_Awaiting_Judicial_Decision_2Def_2Responses() {
+
+        SolicitorDetails solicitorDetails = SolicitorDetails.builder().caseRole("role").build();
+
+        Collections.addAll(respondentSols, element(solicitorDetails), element(solicitorDetails));
+
+        respondentsResponses.add(element(GARespondentResponse.builder()
+                                             .generalAppRespondent1Representative(YES).build()));
+
+        CaseData caseData = getCase(respondentSols, respondentsResponses);
+
+        Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+        });
+        CallbackParams params = callbackParamsOf(dataMap, CallbackType.ABOUT_TO_SUBMIT);
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response).isNotNull();
+        assertThat(response.getState()).isEqualTo("APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+    }
+
+    @Test
+    void shouldReturn_Application_Submitted_Awaiting_Judicial_Decision_1Def_1Response() {
+
+        SolicitorDetails solicitorDetails = SolicitorDetails.builder().caseRole("role").build();
+
+        Collections.addAll(respondentSols, element(solicitorDetails));
+
+        CaseData caseData = getCase(respondentSols, respondentsResponses);
+
+        Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+        });
+        CallbackParams params = callbackParamsOf(dataMap, CallbackType.ABOUT_TO_SUBMIT);
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response).isNotNull();
+        assertThat(response.getState()).isEqualTo("APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+    }
+
+    @Test
+    void shouldReturn_Awaiting_Respondent_Response_2Def_1Response() {
+
+        SolicitorDetails solicitorDetails = SolicitorDetails.builder().caseRole("role").build();
+
+        Collections.addAll(respondentSols, element(solicitorDetails), element(solicitorDetails));
+
+        CaseData caseData = getCase(respondentSols, respondentsResponses);
+
+        Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+        });
+        CallbackParams params = callbackParamsOf(dataMap, CallbackType.ABOUT_TO_SUBMIT);
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response).isNotNull();
+        assertThat(response.getState()).isEqualTo("AWAITING_RESPONDENT_RESPONSE");
+    }
+
+    @Test
+    void shouldReturn_Awaiting_Respondent_Response_For_NoDef_NoResponse() {
+
+        CaseData caseData = getCase();
+
+        Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+        });
+        CallbackParams params = callbackParamsOf(dataMap, CallbackType.ABOUT_TO_SUBMIT);
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response).isNotNull();
+        assertThat(response.getState()).isEqualTo("AWAITING_RESPONDENT_RESPONSE");
+    }
+
     private CaseData getCaseWithNullUnavailableDateFrom() {
         return CaseData.builder()
             .hearingDetailsResp(GAHearingDetails.builder()
@@ -338,6 +451,32 @@ public class RespondToApplicationHandlerTest extends BaseCallbackHandlerTest {
         List<GeneralApplicationTypes> types = List.of(
             (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
         return CaseData.builder()
+            .generalAppRespondent1Representative(
+                GARespondentRepresentative.builder()
+                    .generalAppRespondent1Representative(YES)
+                    .build())
+            .generalAppType(
+                GAApplicationType
+                    .builder()
+                    .types(types).build())
+            .businessProcess(BusinessProcess
+                                 .builder()
+                                 .camundaEvent(CAMUNDA_EVENT)
+                                 .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
+                                 .status(BusinessProcessStatus.STARTED)
+                                 .activityId(ACTIVITY_ID)
+                                 .build())
+            .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
+            .build();
+    }
+
+    private CaseData getCase(List<Element<SolicitorDetails>> defendantSolicitors,
+                             List<Element<GARespondentResponse>> respondentsResponses) {
+        List<GeneralApplicationTypes> types = List.of(
+            (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+        return CaseData.builder()
+            .defendantSolicitors(defendantSolicitors)
+            .respondentsResponses(respondentsResponses)
             .generalAppRespondent1Representative(
                 GARespondentRepresentative.builder()
                     .generalAppRespondent1Representative(YES)


### PR DESCRIPTION
Description:

Create model to store Applicant and respondant solicitors. Filter and populate
Solicitors lists and commit it to GA

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-316

### Read Me ###

1. While assigning the roles, you know the solicitors, save them in CCD (General App CCD Def). 

2. Before the respondents response, the GA case will be in Awaiting Respondents Response state, once they submit the response it will go into Awaiting Judicial Decision. If there are multiple respondents then wait for both the responses before moving the case to Awaiting Judicial Decision. 

3. Create a Collection of Responses in GA CCD Definition, on submit of the response take the data and add it to the collection. 

4. On Summary Tab, display the collection of data separately. 

### Change description ###

- While assigning the roles, you know the solicitors, save them in CCD (General App CCD Def). 

- Create a Collection of Responses in GA CCD Definition, on submit of the response take the data and add it to the collection. 



### Related PRs ###
https://github.com/hmcts/civil-general-apps-ccd-definition/pull/89

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
