### PR TITLE
CIV-1725 Populate Vulnerability - Part 1

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/GAJudgeOrderClaimantOrDefenseFixedList.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/GAJudgeOrderClaimantOrDefenseFixedList.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.civil.enums;
 
 public enum GAJudgeOrderClaimantOrDefenseFixedList {
-    CLAIMANT,
-    DEFENSE
+    CLAIM_FORM,
+    DEFENSE_FORM
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/GAJudgeOrderClaimantOrDefenseFixedList.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/GAJudgeOrderClaimantOrDefenseFixedList.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.reform.civil.enums;
+
+public enum GAJudgeOrderClaimantOrDefenseFixedList {
+    CLAIMANT,
+    DEFENSE
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GAJudgesHearingListGAspec.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GAJudgesHearingListGAspec.java
@@ -28,6 +28,7 @@ public class GAJudgesHearingListGAspec {
     private String judgeHearingCourtLocationText1;
     private String hearingPreferencesPreferredTypeLabel1;
     private String judgeHearingSupportReqText1;
+    private String judicialVulnerabilityText;
 
     @JsonCreator
     GAJudgesHearingListGAspec(@JsonProperty("hearingPreferencesPreferredType")
@@ -43,7 +44,8 @@ public class GAJudgesHearingListGAspec {
                               @JsonProperty("judgeHearingCourtLocationText1") String judgeHearingCourtLocationText1,
                               @JsonProperty("hearingPreferencesPreferredTypeLabel1")
                                   String hearingPreferencesPreferredTypeLabel1,
-                              @JsonProperty("judgeHearingSupportReqText1") String judgeHearingSupportReqText1) {
+                              @JsonProperty("judgeHearingSupportReqText1") String judgeHearingSupportReqText1,
+                              @JsonProperty("judicialVulnerabilityText") String judicialVulnerabilityText) {
 
         this.hearingPreferencesPreferredType = hearingPreferencesPreferredType;
         this.judicialSupportRequirement = judicialSupportRequirement;
@@ -53,6 +55,7 @@ public class GAJudgesHearingListGAspec {
         this.judgeHearingCourtLocationText1 = judgeHearingCourtLocationText1;
         this.hearingPreferencesPreferredTypeLabel1 = hearingPreferencesPreferredTypeLabel1;
         this.judgeHearingSupportReqText1 = judgeHearingSupportReqText1;
+        this.judicialVulnerabilityText = judicialVulnerabilityText;
 
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GAJudicialMakeAnOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GAJudicialMakeAnOrder.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Setter;
+import uk.gov.hmcts.reform.civil.enums.GAJudgeOrderClaimantOrDefenseFixedList;
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.enums.dq.GAJudgeMakeAnOrderOption;
 
 import java.time.LocalDate;
@@ -21,6 +23,10 @@ public class GAJudicialMakeAnOrder {
     private String directionsText;
     private LocalDate directionsResponseByDate;
     private String reasonForDecisionText;
+    private LocalDate judgeApporveEditOptionDate;
+    private YesOrNo displayJudgeApporveEditOptionDate;
+    private YesOrNo displayJudgeApporveEditOptionParty;
+    private GAJudgeOrderClaimantOrDefenseFixedList judgeApporveEditOptionParty;
 
     @JsonCreator
     GAJudicialMakeAnOrder(@JsonProperty("judgeRecitalText") String judgeRecitalText,
@@ -29,7 +35,13 @@ public class GAJudicialMakeAnOrder {
                           @JsonProperty("dismissalOrderText") String dismissalOrderText,
                           @JsonProperty("directionsText") String directionsText,
                           @JsonProperty("directionsResponseByDate") LocalDate directionsResponseByDate,
-                          @JsonProperty("reasonForDecisionText") String reasonForDecisionText) {
+                          @JsonProperty("reasonForDecisionText") String reasonForDecisionText,
+                          @JsonProperty("judgeApporveEditOptionDate") LocalDate judgeApporveEditOptionDate,
+                          @JsonProperty("displayJudgeApporveEditOptionDate") YesOrNo displayJudgeApporveEditOptionDate,
+                          @JsonProperty("displayJudgeApporveEditOptionParty")
+                              YesOrNo displayJudgeApporveEditOptionParty,
+                          @JsonProperty("judgeApporveEditOptionParty")
+                              GAJudgeOrderClaimantOrDefenseFixedList judgeApporveEditOptionParty) {
         this.judgeRecitalText = judgeRecitalText;
         this.makeAnOrder = makeAnOrder;
         this.orderText = orderText;
@@ -37,5 +49,9 @@ public class GAJudicialMakeAnOrder {
         this.directionsText = directionsText;
         this.directionsResponseByDate = directionsResponseByDate;
         this.reasonForDecisionText = reasonForDecisionText;
+        this.judgeApporveEditOptionDate = judgeApporveEditOptionDate;
+        this.displayJudgeApporveEditOptionDate = displayJudgeApporveEditOptionDate;
+        this.displayJudgeApporveEditOptionParty = displayJudgeApporveEditOptionParty;
+        this.judgeApporveEditOptionParty = judgeApporveEditOptionParty;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
@@ -300,7 +300,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
-        void shouldReturnYesForJudgeApproveEditOptionDateIfGATypeIsStayClaim() {
+        void shouldReturnNOForJudgeApproveEditOptionDateIfGATypeIsStayClaim() {
 
             List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STAY_THE_CLAIM));
 
@@ -311,7 +311,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
 
             assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
-                .isEqualTo(YES);
+                .isEqualTo(NO);
 
         }
 
@@ -383,7 +383,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
-        void shouldReturnYesForJudgeApproveEditOptionPartyIfGATypeIsStrikeOut() {
+        void shouldReturnNOForJudgeApproveEditOptionPartyIfGATypeIsStrikeOut() {
 
             List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STRIKE_OUT));
 
@@ -394,7 +394,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
 
             assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
-                .isEqualTo(YES);
+                .isEqualTo(NO);
 
         }
 
@@ -445,7 +445,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
 
             assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
-                .isEqualTo(NO);
+                .isEqualTo(YES);
 
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
@@ -120,22 +120,26 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             String expecetedJudicialTimeEstimateText = " Both applicant and respondent estimate it would take %s.";
             String expecetedJudicialPreferrenceText = " Both applicant and respondent prefer %s.";
 
-            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(), ABOUT_TO_START);
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.STAY_THE_CLAIM), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, YES), ABOUT_TO_START);
+
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
             assertThat(response).isNotNull();
             GAJudgesHearingListGAspec responseCaseData = getJudicialHearingOrder(response);
 
             assertThat(responseCaseData.getJudgeHearingTimeEstimateText1())
-                .isEqualTo(String.format(expecetedJudicialTimeEstimateText, getHearingOrderApplnAndResp()
+                .isEqualTo(String.format(expecetedJudicialTimeEstimateText, getHearingOrderApplnAndResp(types, NO, YES)
                     .getGeneralAppHearingDetails().getHearingDuration().getDisplayedValue()));
 
             assertThat(responseCaseData.getHearingPreferencesPreferredTypeLabel1())
-                .isEqualTo(String.format(expecetedJudicialPreferrenceText, getHearingOrderApplnAndResp()
+                .isEqualTo(String.format(expecetedJudicialPreferrenceText, getHearingOrderApplnAndResp(types, NO, YES)
                     .getGeneralAppHearingDetails().getHearingPreferencesPreferredType().getDisplayedValue()));
 
             assertThat(responseCaseData.getJudgeHearingSupportReqText1())
-                .isEqualTo(getJudgeHearingSupportReqText(getHearingOrderApplnAndResp(), YES));
+                .isEqualTo(getJudgeHearingSupportReqText(getHearingOrderApplnAndResp(types, NO, YES), YES));
 
         }
 
@@ -528,137 +532,9 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
         }
 
-        private GAJudicialMakeAnOrder getJudicialMakeAnOrder(AboutToStartOrSubmitCallbackResponse response) {
-            CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
-            return responseCaseData.getJudicialDecisionMakeOrder();
-        }
-
-        private YesOrNo getApplicationIsCloakedStatus(AboutToStartOrSubmitCallbackResponse response) {
-            CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
-            return responseCaseData.getApplicationIsCloaked();
-        }
-
         private GAJudgesHearingListGAspec getJudicialHearingOrder(AboutToStartOrSubmitCallbackResponse response) {
             CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
             return responseCaseData.getJudicialListForHearing();
-        }
-
-        private CaseData getNotifiedApplication() {
-
-            hasRespondentResponseVul = YES;
-
-            List<GeneralApplicationTypes> types = List.of(
-                    (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
-            return CaseData.builder()
-                    .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
-                    .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
-                    .generalAppDetailsOfOrder("Draft order text entered by applicant.")
-                    .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
-                    .applicantPartyName("ApplicantPartyName")
-                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
-                    .generalAppHearingDetails(GAHearingDetails.builder()
-                                              .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                                              .hearingDuration(GAHearingDuration.HOUR_1)
-                                              .supportRequirement(getApplicantResponses())
-                                              .build())
-                    .generalAppRespondent1Representative(
-                            GARespondentRepresentative.builder()
-                                    .generalAppRespondent1Representative(YES)
-                                    .build())
-                    .generalAppType(
-                            GAApplicationType
-                                    .builder()
-                                    .types(types).build())
-                    .businessProcess(BusinessProcess
-                            .builder()
-                            .camundaEvent(CAMUNDA_EVENT)
-                            .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
-                            .status(BusinessProcessStatus.STARTED)
-                            .activityId(ACTIVITY_ID)
-                            .build())
-                    .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
-                    .build();
-        }
-
-        private CaseData getHearingOrderApplnAndResp() {
-
-            hasRespondentResponseVul = YES;
-
-            List<GeneralApplicationTypes> types = List.of(
-                    (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
-            return CaseData.builder()
-                    .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
-                    .hearingDetailsResp(GAHearingDetails.builder()
-                            .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                            .hearingDuration(GAHearingDuration.HOUR_1)
-                            .supportRequirement(getApplicantResponses())
-                            .build())
-                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
-                    .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
-                    .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
-                    .applicantPartyName("ApplicantPartyName")
-                    .generalAppRespondent1Representative(
-                            GARespondentRepresentative.builder()
-                                    .generalAppRespondent1Representative(YES)
-                                    .build())
-                    .generalAppHearingDetails(GAHearingDetails.builder()
-                                        .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                                        .hearingDuration(GAHearingDuration.HOUR_1)
-                                        .supportRequirement(getApplicantResponses())
-                                        .build())
-                    .generalAppType(
-                            GAApplicationType
-                                    .builder()
-                                    .types(types).build())
-                    .businessProcess(BusinessProcess
-                            .builder()
-                            .camundaEvent(CAMUNDA_EVENT)
-                            .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
-                            .status(BusinessProcessStatus.STARTED)
-                            .activityId(ACTIVITY_ID)
-                            .build())
-                    .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
-                    .build();
-        }
-
-        private CaseData getHearingOrderApplnAndResp(List<GeneralApplicationTypes> types, YesOrNo vulQuestion,
-                                                     YesOrNo hasRespondentResponseVul) {
-
-            return CaseData.builder()
-                .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
-                .hearingDetailsResp(GAHearingDetails.builder()
-                                        .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                                        .hearingDuration(GAHearingDuration.HOUR_1)
-                                        .supportRequirement(getApplicantResponses())
-                                        .build())
-                .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
-                .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
-                .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
-                .applicantPartyName("ApplicantPartyName")
-                .generalAppRespondent1Representative(
-                    GARespondentRepresentative.builder()
-                        .generalAppRespondent1Representative(YES)
-                        .build())
-                .generalAppHearingDetails(GAHearingDetails.builder()
-                                              .vulnerabilityQuestionsYesOrNo(vulQuestion)
-                                              .vulnerabilityQuestion("dummy")
-                                              .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                                              .hearingDuration(GAHearingDuration.HOUR_1)
-                                              .supportRequirement(getApplicantResponses())
-                                              .build())
-                .generalAppType(
-                    GAApplicationType
-                        .builder()
-                        .types(types).build())
-                .businessProcess(BusinessProcess
-                                     .builder()
-                                     .camundaEvent(CAMUNDA_EVENT)
-                                     .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
-                                     .status(BusinessProcessStatus.STARTED)
-                                     .activityId(ACTIVITY_ID)
-                                     .build())
-                .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
-                .build();
         }
 
         private CaseData getCaseDateForUrgentApp() {
@@ -1004,6 +880,52 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
         }
 
+        private CaseData getHearingOrderApplnAndResp(List<SupportRequirements> judgeSupportReqChoices) {
+
+            YesOrNo hasRespondentResponseVul = NO;
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+            return CaseData.builder()
+                .generalAppUrgencyRequirement(GAUrgencyRequirement.builder().generalAppUrgency(YES).build())
+                .judicialListForHearing(GAJudgesHearingListGAspec.builder()
+                                            .judicialSupportRequirement(judgeSupportReqChoices)
+                                            .hearingPreferencesPreferredType(GAJudicialHearingType.VIDEO)
+                                            .judicialTimeEstimate(GAHearingDuration.HOURS_2).build())
+                .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
+                .hearingDetailsResp(GAHearingDetails.builder()
+                                        .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                        .hearingDuration(GAHearingDuration.HOUR_1)
+                                        .supportRequirement(getApplicantResponses())
+                                        .build())
+                .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
+                .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
+                .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
+                .applicantPartyName("ApplicantPartyName")
+                .generalAppHearingDetails(GAHearingDetails.builder()
+                                              .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                              .hearingDuration(GAHearingDuration.HOUR_1)
+                                              .supportRequirement(getApplicantResponses())
+                                              .build())
+                .generalAppRespondent1Representative(
+                    GARespondentRepresentative.builder()
+                        .generalAppRespondent1Representative(YES)
+                        .build())
+                .generalAppType(
+                    GAApplicationType
+                        .builder()
+                        .types(types).build())
+                .businessProcess(BusinessProcess
+                                     .builder()
+                                     .camundaEvent(CAMUNDA_EVENT)
+                                     .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
+                                     .status(BusinessProcessStatus.STARTED)
+                                     .activityId(ACTIVITY_ID)
+                                     .build())
+                .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
+                .build();
+        }
+
         public CaseData getSequentialWrittenRepresentationDecision(LocalDate writtenRepresentationDate) {
 
             GAJudicialWrittenRepresentations.GAJudicialWrittenRepresentationsBuilder
@@ -1030,6 +952,96 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                     .judicialDecisionMakeAnOrderForWrittenRepresentations(gaJudicialWrittenRepresentations).build();
         }
 
+    }
+
+    @Nested
+    class MidEventForMakeAnOrderOption {
+
+        private static final String VALIDATE_MAKE_AN_ORDER = "validate-make-an-order";
+
+        @Test
+        void shouldReturnNOForJudgeApproveEditOptionDate() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STAY_THE_CLAIM));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), MID,
+                                                     VALIDATE_MAKE_AN_ORDER);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(NO);
+        }
+
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionDate() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STAY_THE_CLAIM),
+                                                          (GeneralApplicationTypes.EXTEND_TIME));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), MID,
+                                                     VALIDATE_MAKE_AN_ORDER);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(YES);
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApproveEditOptionParty() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), MID,
+                                                     VALIDATE_MAKE_AN_ORDER);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(NO);
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApporveEditOptionParty() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), MID,
+                                                     VALIDATE_MAKE_AN_ORDER);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(YES);
+        }
+
+        @Test
+        void testAboutToStartForNotifiedApplication() {
+            String expectedRecitalText = "Upon reading the application of Claimant dated 15 January 22 and upon the "
+                + "application of ApplicantPartyName dated %s and upon considering the information "
+                + "provided by the parties";
+
+            CallbackParams params = callbackParamsOf(getNotifiedApplication(), MID, VALIDATE_MAKE_AN_ORDER);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getJudgeRecitalText())
+                .isEqualTo(String.format(expectedRecitalText, DATE_FORMATTER.format(LocalDate.now())));
+            assertThat(makeAnOrder.getDismissalOrderText()).isEqualTo(expectedDismissalOrder);
+        }
     }
 
     @Nested
@@ -1376,18 +1388,10 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
         }
     }
 
-    public CaseData getHearingOrderApplnAndResp(List<SupportRequirements> judgeSupportReqChoices) {
+    public CaseData getHearingOrderApplnAndResp(List<GeneralApplicationTypes> types, YesOrNo vulQuestion,
+                                                 YesOrNo hasRespondentResponseVul) {
 
-        YesOrNo hasRespondentResponseVul = NO;
-
-        List<GeneralApplicationTypes> types = List.of(
-            (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
         return CaseData.builder()
-            .generalAppUrgencyRequirement(GAUrgencyRequirement.builder().generalAppUrgency(YES).build())
-            .judicialListForHearing(GAJudgesHearingListGAspec.builder()
-                                        .judicialSupportRequirement(judgeSupportReqChoices)
-                                        .hearingPreferencesPreferredType(GAJudicialHearingType.VIDEO)
-                                        .judicialTimeEstimate(GAHearingDuration.HOURS_2).build())
             .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
             .hearingDetailsResp(GAHearingDetails.builder()
                                     .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
@@ -1398,15 +1402,17 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
             .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
             .applicantPartyName("ApplicantPartyName")
-            .generalAppHearingDetails(GAHearingDetails.builder()
-                                          .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
-                                          .hearingDuration(GAHearingDuration.HOUR_1)
-                                          .supportRequirement(getApplicantResponses())
-                                          .build())
             .generalAppRespondent1Representative(
                 GARespondentRepresentative.builder()
                     .generalAppRespondent1Representative(YES)
                     .build())
+            .generalAppHearingDetails(GAHearingDetails.builder()
+                                          .vulnerabilityQuestionsYesOrNo(vulQuestion)
+                                          .vulnerabilityQuestion("dummy")
+                                          .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                          .hearingDuration(GAHearingDuration.HOUR_1)
+                                          .supportRequirement(getApplicantResponses())
+                                          .build())
             .generalAppType(
                 GAApplicationType
                     .builder()
@@ -1453,6 +1459,53 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             .add(GAHearingSupportRequirements.OTHER_SUPPORT);
 
         return applSupportReq;
+    }
+
+    public CaseData getNotifiedApplication() {
+
+        YesOrNo hasRespondentResponseVul = YES;
+
+        List<GeneralApplicationTypes> types = List.of(
+            (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+        return CaseData.builder()
+            .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
+            .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
+            .generalAppDetailsOfOrder("Draft order text entered by applicant.")
+            .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
+            .applicantPartyName("ApplicantPartyName")
+            .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
+            .generalAppHearingDetails(GAHearingDetails.builder()
+                                          .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                          .hearingDuration(GAHearingDuration.HOUR_1)
+                                          .supportRequirement(getApplicantResponses())
+                                          .build())
+            .generalAppRespondent1Representative(
+                GARespondentRepresentative.builder()
+                    .generalAppRespondent1Representative(YES)
+                    .build())
+            .generalAppType(
+                GAApplicationType
+                    .builder()
+                    .types(types).build())
+            .businessProcess(BusinessProcess
+                                 .builder()
+                                 .camundaEvent(CAMUNDA_EVENT)
+                                 .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
+                                 .status(BusinessProcessStatus.STARTED)
+                                 .activityId(ACTIVITY_ID)
+                                 .build())
+            .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
+            .build();
+    }
+
+    public GAJudicialMakeAnOrder getJudicialMakeAnOrder(AboutToStartOrSubmitCallbackResponse response) {
+        CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
+        return responseCaseData.getJudicialDecisionMakeOrder();
+    }
+
+    public YesOrNo getApplicationIsCloakedStatus(AboutToStartOrSubmitCallbackResponse response) {
+        CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
+        return responseCaseData.getApplicationIsCloaked();
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialDecisionHandlerTest.java
@@ -110,6 +110,8 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
     @Nested
     class AboutToStartCallbackHandling {
 
+        YesOrNo hasRespondentResponseVul = NO;
+
         @Test
         void testAboutToStartForHearingGeneralOrderRecital() {
 
@@ -265,6 +267,235 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
         }
 
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionDateIfGATypeIsStayClaim() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STAY_THE_CLAIM));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(YES);
+
+        }
+
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionDateIfGATypeIsStayClaimAndExtendTime() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STAY_THE_CLAIM),
+                                                          (GeneralApplicationTypes.EXTEND_TIME));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(YES);
+
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApproveEditOptionDateIfGATypesIsNotEitherExtendTimeORStayClaim() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(NO);
+
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApporveEditOptionDateIfGATypesIsNotEitherExtendTimeORStayClaim() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.STAY_THE_CLAIM), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionDate())
+                .isEqualTo(NO);
+
+        }
+
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionPartyIfGATypeIsExtendTime() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.EXTEND_TIME));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(YES);
+
+        }
+
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionPartyIfGATypeIsStrikeOut() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STRIKE_OUT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(YES);
+
+        }
+
+        @Test
+        void shouldReturnYesForJudgeApproveEditOptionPartyIfGATypeIsStayClaimAndExtendTime() {
+
+            List<GeneralApplicationTypes> types = List.of((GeneralApplicationTypes.STRIKE_OUT),
+                                                          (GeneralApplicationTypes.EXTEND_TIME));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(YES);
+
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApproveEditOptionPartyIfGATypesIsNotEitherExtendTimeORStayClaim() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(NO);
+
+        }
+
+        @Test
+        void shouldReturnNOForJudgeApporveEditOptionPartyIfGATypesIsNotEitherExtendTimeORStrikeOut() {
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudicialMakeAnOrder makeAnOrder = getJudicialMakeAnOrder(response);
+
+            assertThat(makeAnOrder.getDisplayJudgeApporveEditOptionParty())
+                .isEqualTo(NO);
+
+        }
+
+        @Test
+        void shouldMatchExpectedVulnerabilityText() {
+
+            String expecetedVulnerabilityText = "Applicant requires support with regards to vulnerability\n"
+                + "dummy\n\nRespondent requires support with regards to vulnerability\ndummy";
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, YES, YES), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudgesHearingListGAspec responseCaseData = getJudicialHearingOrder(response);
+
+            assertThat(responseCaseData.getJudicialVulnerabilityText())
+                .isEqualTo(expecetedVulnerabilityText);
+
+        }
+
+        @Test
+        void shouldHaveVulTextWithRespondentRespond() {
+
+            String expecetedVulnerabilityText = "Respondent requires support with regards to vulnerability\n"
+                + "dummy";
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, YES), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudgesHearingListGAspec responseCaseData = getJudicialHearingOrder(response);
+
+            assertThat(responseCaseData.getJudicialVulnerabilityText())
+                .isEqualTo(expecetedVulnerabilityText);
+
+        }
+
+        @Test
+        void shouldHaveVulTextWithApplicantRespond() {
+
+            String expecetedVulnerabilityText = "Applicant requires support with regards to vulnerability\n"
+                + "dummy";
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, YES, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudgesHearingListGAspec responseCaseData = getJudicialHearingOrder(response);
+
+            assertThat(responseCaseData.getJudicialVulnerabilityText())
+                .isEqualTo(expecetedVulnerabilityText);
+
+        }
+
+        @Test
+        void shouldReturnExpectedTextWithNOVulRespond() {
+
+            String expecetedVulnerabilityText = "No support required with regards to vulnerability";
+
+            List<GeneralApplicationTypes> types = List.of(
+                (GeneralApplicationTypes.EXTEND_TIME), (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            CallbackParams params = callbackParamsOf(getHearingOrderApplnAndResp(types, NO, NO), ABOUT_TO_START);
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response).isNotNull();
+            GAJudgesHearingListGAspec responseCaseData = getJudicialHearingOrder(response);
+
+            assertThat(responseCaseData.getJudicialVulnerabilityText())
+                .isEqualTo(expecetedVulnerabilityText);
+
+        }
+
         private GAJudicialMakeAnOrder getJudicialMakeAnOrder(AboutToStartOrSubmitCallbackResponse response) {
             CaseData responseCaseData = objectMapper.convertValue(response.getData(), CaseData.class);
             return responseCaseData.getJudicialDecisionMakeOrder();
@@ -282,6 +513,8 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
         private CaseData getNotifiedApplication() {
 
+            hasRespondentResponseVul = YES;
+
             List<GeneralApplicationTypes> types = List.of(
                     (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
             return CaseData.builder()
@@ -290,7 +523,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                     .generalAppDetailsOfOrder("Draft order text entered by applicant.")
                     .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
                     .applicantPartyName("ApplicantPartyName")
-                    .respondentsResponses(getRespodentResponses())
+                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                     .generalAppHearingDetails(GAHearingDetails.builder()
                                               .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
                                               .hearingDuration(GAHearingDuration.HOUR_1)
@@ -317,6 +550,8 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
         private CaseData getHearingOrderApplnAndResp() {
 
+            hasRespondentResponseVul = YES;
+
             List<GeneralApplicationTypes> types = List.of(
                     (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
             return CaseData.builder()
@@ -326,7 +561,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                             .hearingDuration(GAHearingDuration.HOUR_1)
                             .supportRequirement(getApplicantResponses())
                             .build())
-                    .respondentsResponses(getRespodentResponses())
+                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                     .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
                     .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
                     .applicantPartyName("ApplicantPartyName")
@@ -354,7 +589,49 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                     .build();
         }
 
+        private CaseData getHearingOrderApplnAndResp(List<GeneralApplicationTypes> types, YesOrNo vulQuestion,
+                                                     YesOrNo hasRespondentResponseVul) {
+
+            return CaseData.builder()
+                .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
+                .hearingDetailsResp(GAHearingDetails.builder()
+                                        .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                        .hearingDuration(GAHearingDuration.HOUR_1)
+                                        .supportRequirement(getApplicantResponses())
+                                        .build())
+                .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
+                .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
+                .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
+                .applicantPartyName("ApplicantPartyName")
+                .generalAppRespondent1Representative(
+                    GARespondentRepresentative.builder()
+                        .generalAppRespondent1Representative(YES)
+                        .build())
+                .generalAppHearingDetails(GAHearingDetails.builder()
+                                              .vulnerabilityQuestionsYesOrNo(vulQuestion)
+                                              .vulnerabilityQuestion("dummy")
+                                              .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
+                                              .hearingDuration(GAHearingDuration.HOUR_1)
+                                              .supportRequirement(getApplicantResponses())
+                                              .build())
+                .generalAppType(
+                    GAApplicationType
+                        .builder()
+                        .types(types).build())
+                .businessProcess(BusinessProcess
+                                     .builder()
+                                     .camundaEvent(CAMUNDA_EVENT)
+                                     .processInstanceId(BUSINESS_PROCESS_INSTANCE_ID)
+                                     .status(BusinessProcessStatus.STARTED)
+                                     .activityId(ACTIVITY_ID)
+                                     .build())
+                .ccdState(CaseState.APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION)
+                .build();
+        }
+
         private CaseData getCaseDateForUrgentApp() {
+
+            hasRespondentResponseVul = NO;
 
             List<GeneralApplicationTypes> types = List.of(
                 (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
@@ -366,7 +643,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                                         .hearingDuration(GAHearingDuration.HOUR_1)
                                         .supportRequirement(getApplicantResponses())
                                         .build())
-                .respondentsResponses(getRespodentResponses())
+                .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                 .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
                 .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
                 .applicantPartyName("ApplicantPartyName")
@@ -398,6 +675,9 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
             List<GeneralApplicationTypes> types = List.of(
                 (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            hasRespondentResponseVul = NO;
+
             return CaseData.builder()
                 .generalAppUrgencyRequirement(GAUrgencyRequirement.builder().generalAppUrgency(YES).build())
                 .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
@@ -406,7 +686,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                                         .hearingDuration(GAHearingDuration.HOUR_1)
                                         .supportRequirement(getApplicantResponses())
                                         .build())
-                .respondentsResponses(getRespodentResponses())
+                .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                 .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
                 .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
                 .applicantPartyName("ApplicantPartyName")
@@ -437,10 +717,13 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
             List<GeneralApplicationTypes> types = List.of(
                     (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            hasRespondentResponseVul = NO;
+
             return CaseData.builder()
                     .parentClaimantIsApplicant(YES)
                     .generalAppRespondentAgreement(GARespondentOrderAgreement.builder().hasAgreed(NO).build())
-                    .respondentsResponses(getRespodentResponses())
+                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                     .generalAppHearingDetails(GAHearingDetails.builder()
                                               .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
                                               .hearingDuration(GAHearingDuration.HOUR_1)
@@ -473,13 +756,16 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
             List<GeneralApplicationTypes> types = List.of(
                     (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
+
+            hasRespondentResponseVul = NO;
+
             return CaseData.builder()
                     .parentClaimantIsApplicant(NO)
                     .judicialDecisionMakeOrder(GAJudicialMakeAnOrder.builder().build())
                     .generalAppDetailsOfOrder("Draft order text entered by applicant.")
                     .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
                     .applicantPartyName("ApplicantPartyName")
-                    .respondentsResponses(getRespodentResponses())
+                    .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
                     .generalAppHearingDetails(GAHearingDetails.builder()
                                               .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
                                               .hearingDuration(GAHearingDuration.HOUR_1)
@@ -992,6 +1278,8 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
 
     public CaseData getHearingOrderApplnAndResp() {
 
+        YesOrNo hasRespondentResponseVul = NO;
+
         List<GeneralApplicationTypes> types = List.of(
             (GeneralApplicationTypes.SUMMARY_JUDGEMENT));
         return CaseData.builder()
@@ -1005,7 +1293,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
                                     .hearingDuration(GAHearingDuration.HOUR_1)
                                     .supportRequirement(getApplicantResponses())
                                     .build())
-            .respondentsResponses(getRespodentResponses())
+            .respondentsResponses(getRespodentResponses(hasRespondentResponseVul))
             .generalAppInformOtherParty(GAInformOtherParty.builder().isWithNotice(YES).build())
             .createdDate(LocalDateTime.of(2022, 1, 15, 0, 0, 0))
             .applicantPartyName("ApplicantPartyName")
@@ -1033,7 +1321,7 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
             .build();
     }
 
-    public List<Element<GARespondentResponse>> getRespodentResponses() {
+    public List<Element<GARespondentResponse>> getRespodentResponses(YesOrNo vulQuestion) {
 
         List<GAHearingSupportRequirements> respSupportReq = new ArrayList<>();
         respSupportReq
@@ -1045,6 +1333,8 @@ public class JudicialDecisionHandlerTest extends BaseCallbackHandlerTest {
         respondentsResponses
             .add(element(GARespondentResponse.builder()
                              .gaHearingDetails(GAHearingDetails.builder()
+                                                   .vulnerabilityQuestionsYesOrNo(vulQuestion)
+                                                   .vulnerabilityQuestion("dummy")
                                                    .hearingPreferencesPreferredType(GAHearingType.IN_PERSON)
                                                    .hearingDuration(GAHearingDuration.HOUR_1)
                                                    .supportRequirement(respSupportReq)


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1725


### Change description ###

1. Create Callback to populate Vulnerability text to the Judge's screens with Applicant and Respondent selection
2.  Create Callback to implement the visibility of Order dropdown and date for General Applications Order Screen

DATE FIELD DETAILS

Available when application type includes: Extend Time, Stay the Claim

DROPDOWN DETAILS

Available when application type includes: Extend Time, Strike Out

### Related PR ###
https://github.com/hmcts/civil-general-apps-ccd-definition/pull/132


### Read Me ###

Please take a look at the attached word file

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
