### PR TITLE
Feature/civ 3210 offline rpa application json

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/GeneralApplication.java
@@ -50,6 +50,7 @@ public class GeneralApplication implements MappableObject {
     private final String claimant2PartyName;
     private final String defendant1PartyName;
     private final String defendant2PartyName;
+    private final String litigiousPartyID;
 
     @JsonCreator
     GeneralApplication(@JsonProperty("generalAppType") GAApplicationType generalAppType,
@@ -81,7 +82,8 @@ public class GeneralApplication implements MappableObject {
                        @JsonProperty("claimant1PartyName") String claimant1PartyName,
                        @JsonProperty("claimant2PartyName") String claimant2PartyName,
                        @JsonProperty("defendant1PartyName") String defendant1PartyName,
-                       @JsonProperty("defendant2PartyName") String defendant2PartyName) {
+                       @JsonProperty("defendant2PartyName") String defendant2PartyName,
+                       @JsonProperty("litigiousPartyID") String litigiousPartyID) {
         this.generalAppType = generalAppType;
         this.generalAppRespondentAgreement = generalAppRespondentAgreement;
         this.businessProcess = businessProcess;
@@ -110,6 +112,7 @@ public class GeneralApplication implements MappableObject {
         this.claimant2PartyName = claimant2PartyName;
         this.defendant1PartyName = defendant1PartyName;
         this.defendant2PartyName = defendant2PartyName;
+        this.litigiousPartyID = litigiousPartyID;
     }
 
     @JsonIgnore


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-3210

### Change description ###
RPA should only be triggered when a Main Case is taken offline (State - Case Proceeds Offline) and Strike Out Defence order is given by the Judge.  A Strike Out Defence order should update the application state to 'Proceeds in Heritage' which in turn should trigger the 2 RPA tasks to update caseman.  Strike Out defence can be identified when it is the Main Case Claimant (Applicant) who created the application to Strike Out.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
