### PR TITLE
CIV-6314 Dont overwrite judge order documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GeneratePDFDocumentCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GeneratePDFDocumentCallbackHandler.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.service.docmosis.directionorder.DirectionOrderGenerator;
 import uk.gov.hmcts.reform.civil.service.docmosis.dismissalorder.DismissalOrderGenerator;
@@ -23,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Optional.ofNullable;
 import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.GENERATE_JUDGES_FORM;
@@ -87,7 +90,14 @@ public class GeneratePDFDocumentCallbackHandler extends CallbackHandler {
                 caseDataBuilder.build(),
                 callbackParams.getParams().get(BEARER_TOKEN).toString()
             );
-            caseDataBuilder.directionOrderDocument(wrapElements(judgeDecision));
+
+            List<Element<CaseDocument>> newDirectionOrderDocumentList =
+                ofNullable(caseData.getDirectionOrderDocument()).orElse(newArrayList());
+
+            newDirectionOrderDocumentList.addAll(wrapElements(judgeDecision));
+
+            caseDataBuilder.directionOrderDocument(newDirectionOrderDocumentList);
+
         } else if (caseData.getJudicialDecision().getDecision().equals(MAKE_AN_ORDER)
             && caseData.getJudicialDecisionMakeOrder().getMakeAnOrder().equals(DISMISS_THE_APPLICATION)) {
             judgeDecision = dismissalOrderGenerator.generate(
@@ -111,7 +121,14 @@ public class GeneratePDFDocumentCallbackHandler extends CallbackHandler {
                     caseDataBuilder.build(),
                     callbackParams.getParams().get(BEARER_TOKEN).toString()
                 );
-            caseDataBuilder.writtenRepSequentialDocument(wrapElements(judgeDecision));
+
+            List<Element<CaseDocument>> newWrittenRepSequentialDocumentList =
+                ofNullable(caseData.getWrittenRepSequentialDocument()).orElse(newArrayList());
+
+            newWrittenRepSequentialDocumentList.addAll(wrapElements(judgeDecision));
+
+            caseDataBuilder.writtenRepSequentialDocument(newWrittenRepSequentialDocumentList);
+
         } else if (caseData.getJudicialDecision().getDecision().equals(MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS)
             && caseData.getJudicialDecisionMakeAnOrderForWrittenRepresentations()
             .getWrittenConcurrentRepresentationsBy() != null) {
@@ -119,7 +136,14 @@ public class GeneratePDFDocumentCallbackHandler extends CallbackHandler {
                 caseDataBuilder.build(),
                 callbackParams.getParams().get(BEARER_TOKEN).toString()
             );
-            caseDataBuilder.writtenRepConcurrentDocument(wrapElements(judgeDecision));
+
+            List<Element<CaseDocument>> newWrittenRepConcurrentDocumentList =
+                ofNullable(caseData.getWrittenRepConcurrentDocument()).orElse(newArrayList());
+
+            newWrittenRepConcurrentDocumentList.addAll(wrapElements(judgeDecision));
+
+            caseDataBuilder.writtenRepConcurrentDocument(newWrittenRepConcurrentDocumentList);
+
         } else if (caseData.getJudicialDecision().getDecision().equals(REQUEST_MORE_INFO)
             && caseData.getJudicialDecisionRequestMoreInfo().getJudgeRequestMoreInfoByDate() != null
             && caseData.getJudicialDecisionRequestMoreInfo().getJudgeRequestMoreInfoText() != null) {
@@ -127,7 +151,13 @@ public class GeneratePDFDocumentCallbackHandler extends CallbackHandler {
                 caseDataBuilder.build(),
                 callbackParams.getParams().get(BEARER_TOKEN).toString()
             );
-            caseDataBuilder.requestForInformationDocument(wrapElements(judgeDecision));
+
+            List<Element<CaseDocument>> newRequestForInfoDocumentList =
+                ofNullable(caseData.getRequestForInformationDocument()).orElse(newArrayList());
+
+            newRequestForInfoDocumentList.addAll(wrapElements(judgeDecision));
+
+            caseDataBuilder.requestForInformationDocument(newRequestForInfoDocumentList);
         }
 
         return AboutToStartOrSubmitCallbackResponse.builder()

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.DIRECTION_ORDER;
 
@@ -38,13 +40,15 @@ public class DirectionOrderGenerator implements TemplateDataGenerator<JudgeDecis
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.DIRECTION_ORDER)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.DISMISSAL_ORDER;
 
@@ -38,13 +40,15 @@ public class DismissalOrderGenerator implements TemplateDataGenerator<JudgeDecis
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.DISMISSAL_ORDER)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.GENERAL_ORDER;
 
@@ -38,13 +40,15 @@ public class GeneralOrderGenerator implements TemplateDataGenerator<JudgeDecisio
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.GENERAL_ORDER)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.HEARING_ORDER;
 
@@ -38,13 +40,15 @@ public class HearingOrderGenerator implements TemplateDataGenerator<JudgeDecisio
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.HEARING_ORDER)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/requestmoreinformation/RequestForInformationGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/requestmoreinformation/RequestForInformationGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.REQUEST_FOR_INFORMATION;
 
@@ -38,13 +40,14 @@ public class RequestForInformationGenerator implements TemplateDataGenerator<Jud
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.REQUEST_FOR_INFORMATION)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationconcurrentorder/WrittenRepresentationConcurrentOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationconcurrentorder/WrittenRepresentationConcurrentOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.WRITTEN_REPRESENTATION_CONCURRENT;
 
@@ -38,13 +40,14 @@ public class WrittenRepresentationConcurrentOrderGenerator implements TemplateDa
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.WRITTEN_REPRESENTATION_CONCURRENT)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationsequentialorder/WrittenRepresentationSequentailOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationsequentialorder/WrittenRepresentationSequentailOrderGenerator.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.civil.service.docmosis.TemplateDataGenerator;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentManagementService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.WRITTEN_REPRESENTATION_SEQUENTIAL;
 
@@ -38,13 +40,14 @@ public class WrittenRepresentationSequentailOrderGenerator implements TemplateDa
 
         return documentManagementService.uploadDocument(
             authorisation,
-            new PDF(getFileName(docmosisTemplate, caseData), docmosisDocument.getBytes(),
+            new PDF(getFileName(docmosisTemplate), docmosisDocument.getBytes(),
                     DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL)
         );
     }
 
-    private String getFileName(DocmosisTemplates docmosisTemplate, CaseData caseData) {
-        return String.format(docmosisTemplate.getDocumentTitle(), caseData.getCcdCaseReference());
+    private String getFileName(DocmosisTemplates docmosisTemplate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return String.format(docmosisTemplate.getDocumentTitle(), LocalDateTime.now().format(formatter));
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GeneratePDFDocumentCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GeneratePDFDocumentCallbackHandlerTest.java
@@ -16,6 +16,9 @@ import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
+import uk.gov.hmcts.reform.civil.model.documents.Document;
+import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.PDFBuilder;
 import uk.gov.hmcts.reform.civil.service.Time;
@@ -37,6 +40,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {
@@ -135,6 +139,29 @@ class GeneratePDFDocumentCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
+        void shouldHaveListOfTwoGenerateDirectionOrderDocIfElementInListAlreadyPresent() {
+
+            CaseDocument caseDocument = CaseDocument.builder().documentName("abcd")
+                .documentLink(Document.builder().documentUrl("url").documentFileName("filename").documentHash("hash")
+                                  .documentBinaryUrl("binaryUrl").build())
+                .documentType(DocumentType.DIRECTION_ORDER).documentSize(12L).build();
+
+            CaseData caseData = CaseDataBuilder.builder().directionOrderApplication()
+                .directionOrderDocument(wrapElements(caseDocument))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            verify(directionOrderGenerator).generate(any(CaseData.class), eq("BEARER_TOKEN"));
+
+            CaseData updatedData = mapper.convertValue(response.getData(), CaseData.class);
+
+            assertThat(updatedData.getDirectionOrderDocument().size()).isEqualTo(2);
+            assertThat(updatedData.getSubmittedOn()).isEqualTo(submittedOn);
+        }
+
+        @Test
         void shouldGenerateDismissalOrderDocument_whenAboutToSubmitEventIsCalled() {
             CaseData caseData = CaseDataBuilder.builder().dismissalOrderApplication()
                 .build();
@@ -186,6 +213,30 @@ class GeneratePDFDocumentCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
+        void shouldHaveListOfTwoGenerateWrittenRepSequentialDocIfElementInListAlreadyPresent() {
+
+            CaseDocument caseDocument = CaseDocument.builder().documentName("abcd")
+                .documentLink(Document.builder().documentUrl("url").documentFileName("filename").documentHash("hash")
+                                  .documentBinaryUrl("binaryUrl").build())
+                .documentType(DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL).documentSize(12L).build();
+
+            CaseData caseData = CaseDataBuilder.builder().writtenRepresentationSequentialApplication()
+                .writtenRepSequentialDocument(wrapElements(caseDocument))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            verify(writtenRepresentationSequentailOrderGenerator)
+                .generate(any(CaseData.class), eq("BEARER_TOKEN"));
+
+            CaseData updatedData = mapper.convertValue(response.getData(), CaseData.class);
+
+            assertThat(updatedData.getWrittenRepSequentialDocument().size()).isEqualTo(2);
+            assertThat(updatedData.getSubmittedOn()).isEqualTo(submittedOn);
+        }
+
+        @Test
         void shouldGenerateWrittenRepresentationConccurentDocument_whenAboutToSubmitEventIsCalled() {
             CaseData caseData = CaseDataBuilder.builder().writtenRepresentationConcurrentApplication()
                 .build();
@@ -203,6 +254,30 @@ class GeneratePDFDocumentCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
+        void shouldHaveListOfTwoGenerateWrittenRepConcurrentDocIfElementInListAlreadyPresent() {
+
+            CaseDocument caseDocument = CaseDocument.builder().documentName("abcd")
+                .documentLink(Document.builder().documentUrl("url").documentFileName("filename").documentHash("hash")
+                                  .documentBinaryUrl("binaryUrl").build())
+                .documentType(DocumentType.WRITTEN_REPRESENTATION_CONCURRENT).documentSize(12L).build();
+
+            CaseData caseData = CaseDataBuilder.builder().writtenRepresentationConcurrentApplication()
+                .writtenRepConcurrentDocument(wrapElements(caseDocument))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            verify(writtenRepresentationConcurrentOrderGenerator)
+                .generate(any(CaseData.class), eq("BEARER_TOKEN"));
+
+            CaseData updatedData = mapper.convertValue(response.getData(), CaseData.class);
+
+            assertThat(updatedData.getWrittenRepConcurrentDocument().size()).isEqualTo(2);
+            assertThat(updatedData.getSubmittedOn()).isEqualTo(submittedOn);
+        }
+
+        @Test
         void shouldGenerateRequestForInformationDocument_whenAboutToSubmitEventIsCalled() {
             CaseData caseData = CaseDataBuilder.builder().requestForInformationApplication()
                 .build();
@@ -216,6 +291,30 @@ class GeneratePDFDocumentCallbackHandlerTest extends BaseCallbackHandlerTest {
 
             assertThat(updatedData.getRequestForInformationDocument().get(0).getValue())
                 .isEqualTo(PDFBuilder.REQUEST_FOR_INFORMATION_DOCUMENT);
+            assertThat(updatedData.getSubmittedOn()).isEqualTo(submittedOn);
+        }
+
+        @Test
+        void shouldHaveListOfTwoGenerateRequestForInfotDocIfElementInListAlreadyPresent() {
+
+            CaseDocument caseDocument = CaseDocument.builder().documentName("abcd")
+                .documentLink(Document.builder().documentUrl("url").documentFileName("filename").documentHash("hash")
+                                  .documentBinaryUrl("binaryUrl").build())
+                .documentType(DocumentType.REQUEST_FOR_INFORMATION).documentSize(12L).build();
+
+            CaseData caseData = CaseDataBuilder.builder().requestForInformationApplication()
+                .requestForInformationDocument(wrapElements(caseDocument))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            verify(requestForInformationGenerator)
+                .generate(any(CaseData.class), eq("BEARER_TOKEN"));
+
+            CaseData updatedData = mapper.convertValue(response.getData(), CaseData.class);
+
+            assertThat(updatedData.getRequestForInformationDocument().size()).isEqualTo(2);
             assertThat(updatedData.getSubmittedOn()).isEqualTo(submittedOn);
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGeneratorTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -27,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,13 +42,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.DIREC
 class DirectionOrderGeneratorTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(DIRECTION_ORDER.getDocumentTitle(), REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.DIRECTION_ORDER)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -69,22 +60,15 @@ class DirectionOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(DIRECTION_ORDER)))
             .thenReturn(new DocmosisDocument(DIRECTION_ORDER.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.DIRECTION_ORDER)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = directionOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        directionOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.DIRECTION_ORDER)
+            new PDF(any(), any(), DocumentType.DIRECTION_ORDER)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(DIRECTION_ORDER));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGeneratorTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -27,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,13 +42,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.DISMI
 class DismissalOrderGeneratorTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(DISMISSAL_ORDER.getDocumentTitle(), REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.DISMISSAL_ORDER)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -69,22 +60,15 @@ class DismissalOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(DISMISSAL_ORDER)))
             .thenReturn(new DocmosisDocument(DISMISSAL_ORDER.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.DISMISSAL_ORDER)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = dismissalOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        dismissalOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.DISMISSAL_ORDER)
+            new PDF(any(), any(), DocumentType.DISMISSAL_ORDER)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(DISMISSAL_ORDER));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGeneratorTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -27,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,13 +42,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.GENER
 class GeneralOrderGeneratorTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(GENERAL_ORDER.getDocumentTitle(), REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.GENERAL_ORDER)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -69,22 +60,15 @@ class GeneralOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(GENERAL_ORDER)))
             .thenReturn(new DocmosisDocument(GENERAL_ORDER.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.GENERAL_ORDER)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = generalOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        generalOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.GENERAL_ORDER)
+            new PDF(any(), any(), DocumentType.GENERAL_ORDER)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(GENERAL_ORDER));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -28,8 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,13 +43,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.HEARI
 class HearingOrderGeneratorTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(HEARING_ORDER.getDocumentTitle(), REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.HEARING_ORDER)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -70,22 +61,15 @@ class HearingOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(HEARING_ORDER)))
             .thenReturn(new DocmosisDocument(HEARING_ORDER.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.HEARING_ORDER)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = hearingOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        hearingOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.HEARING_ORDER)
+            new PDF(any(), any(), DocumentType.HEARING_ORDER)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(HEARING_ORDER));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/requestforinformation/RequestForInformationGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/requestforinformation/RequestForInformationGeneratorTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -28,8 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,13 +43,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.REQUE
 class RequestForInformationGeneratorTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(REQUEST_FOR_INFORMATION.getDocumentTitle(), REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.REQUEST_FOR_INFORMATION)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -70,22 +61,15 @@ class RequestForInformationGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(REQUEST_FOR_INFORMATION)))
             .thenReturn(new DocmosisDocument(REQUEST_FOR_INFORMATION.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.REQUEST_FOR_INFORMATION)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = requestForInformationGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        requestForInformationGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.REQUEST_FOR_INFORMATION)
+            new PDF(any(), any(), DocumentType.REQUEST_FOR_INFORMATION)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(REQUEST_FOR_INFORMATION));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationconcurrentorder/WrittenRepresentationConcurrentGeneratorOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationconcurrentorder/WrittenRepresentationConcurrentGeneratorOrderTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -27,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,14 +42,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.WRITT
 class WrittenRepresentationConcurrentGeneratorOrderTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(WRITTEN_REPRESENTATION_CONCURRENT.getDocumentTitle(),
-                                                  REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.WRITTEN_REPRESENTATION_CONCURRENT)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -71,22 +61,15 @@ class WrittenRepresentationConcurrentGeneratorOrderTest {
                                                                eq(WRITTEN_REPRESENTATION_CONCURRENT)))
             .thenReturn(new DocmosisDocument(WRITTEN_REPRESENTATION_CONCURRENT.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.WRITTEN_REPRESENTATION_CONCURRENT)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = writtenRepresentationConcurrentOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        writtenRepresentationConcurrentOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.WRITTEN_REPRESENTATION_CONCURRENT)
+            new PDF(any(), any(), DocumentType.WRITTEN_REPRESENTATION_CONCURRENT)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(WRITTEN_REPRESENTATION_CONCURRENT));

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationsequentialorder/WrittenRepresentationSequentialGeneratorOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/writtenrepresentationsequentialorder/WrittenRepresentationSequentialGeneratorOrderTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisDocument;
 import uk.gov.hmcts.reform.civil.model.docmosis.judgedecisionpdfdocument.JudgeDecisionPdfDocument;
-import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentType;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -27,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,14 +42,7 @@ import static uk.gov.hmcts.reform.civil.service.docmosis.DocmosisTemplates.WRITT
 class WrittenRepresentationSequentialGeneratorOrderTest {
 
     private static final String BEARER_TOKEN = "Bearer Token";
-    private static final Long REFERENCE_NUMBER = 1594901956117591L;
     private static final byte[] bytes = {1, 2, 3, 4, 5, 6};
-    private static final String fileName = format(WRITTEN_REPRESENTATION_SEQUENTIAL.getDocumentTitle(),
-                                                  REFERENCE_NUMBER);
-    private static final CaseDocument CASE_DOCUMENT = CaseDocument.builder()
-        .documentName(fileName)
-        .documentType(DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL)
-        .build();
 
     @MockBean
     private UnsecuredDocumentManagementService documentManagementService;
@@ -71,22 +61,15 @@ class WrittenRepresentationSequentialGeneratorOrderTest {
                                                                eq(WRITTEN_REPRESENTATION_SEQUENTIAL)))
             .thenReturn(new DocmosisDocument(WRITTEN_REPRESENTATION_SEQUENTIAL.getDocumentTitle(), bytes));
 
-        when(documentManagementService.uploadDocument(
-            BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL)
-        ))
-            .thenReturn(CASE_DOCUMENT);
-
         when(listGeneratorService.applicationType(caseData)).thenReturn("Extend time");
         when(listGeneratorService.claimantsName(caseData)).thenReturn("Test Claimant1 Name, Test Claimant2 Name");
         when(listGeneratorService.defendantsName(caseData)).thenReturn("Test Defendant1 Name, Test Defendant2 Name");
 
-        CaseDocument caseDocument = writtenRepresentationSequentailOrderGenerator.generate(caseData, BEARER_TOKEN);
-        assertThat(caseDocument).isNotNull().isEqualTo(CASE_DOCUMENT);
+        writtenRepresentationSequentailOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
             BEARER_TOKEN,
-            new PDF(fileName, bytes, DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL)
+            new PDF(any(), any(), DocumentType.WRITTEN_REPRESENTATION_SEQUENTIAL)
         );
         verify(documentGeneratorService).generateDocmosisDocument(any(JudgeDecisionPdfDocument.class),
                                                                   eq(WRITTEN_REPRESENTATION_SEQUENTIAL));


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Screenshot attached for the Evidence of manual testing
- [ ] Functional, Smoke and API tests have been run locally
- [x] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-6314

### Change description ###

Judge make decision direction order, request for information, written seq and concurrent documents are overwritten if Judge makes the same decision second time. 

documents should not overwrite the original as Judges to see all documents that are created during an application.  In order to have a unique document name we use the date of the document creation instead of the 16 digit application reference.

Naming convention: <DocType>{}for_Application_{_}<DateDocCreated>

### Testing branch and instruction ###

GA
CIV-6314

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
