### PR TITLE
CIV-6625 Set placeholder of court location in hearing doc

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
@@ -75,7 +75,8 @@ public class HearingOrderGenerator implements TemplateDataGenerator<JudgeDecisio
                 .estimatedHearingLength(caseData.getJudicialListForHearing()
                                             .getJudicialTimeEstimate().getDisplayedValue())
                 .submittedOn(getFormattedDate(new Date()))
-                .judicialByCourtsInitiativeListForHearing(populateJudicialByCourtsInitiative(caseData));
+                .judicialByCourtsInitiativeListForHearing(populateJudicialByCourtsInitiative(caseData))
+                .locationName(caseData.getLocationName());
 
         return judgeDecisionPdfDocumentBuilder.build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -609,6 +609,7 @@ public class CaseDataBuilder {
             .claimant2PartyName("Test Claimant2 Name")
             .judicialByCourtsInitiativeListForHearing(GAByCourtsInitiativeGAspec.OPTION_1)
             .defendant1PartyName("Test Defendant1 Name")
+            .locationName("location name")
             .defendant2PartyName("Test Defendant2 Name")
             .applicantPartyName("Test Applicant Name")
             .createdDate(LocalDateTime.now())

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
@@ -101,6 +101,7 @@ class HearingOrderGeneratorTest {
                 () -> assertEquals(templateData.getClaimantName(), getClaimats(caseData)),
                 () -> assertEquals(templateData.getDefendantName(), getDefendats(caseData)),
                 () -> assertEquals(templateData.getApplicationType(), getApplicationType(caseData)),
+                () -> assertEquals(templateData.getLocationName(), caseData.getLocationName()),
                 () -> assertEquals(templateData.getHearingLocation(), caseData.getJudicialListForHearing()
                     .getHearingPreferencesPreferredType().getDisplayedValue()),
                 () -> assertEquals(templateData.getJudicialByCourtsInitiativeListForHearing(), caseData


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Screenshot attached for the Evidence of manual testing
- [ ] Functional, Smoke and API tests have been run locally
- [ ] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-6625

### Change description ###

- On Hearing Notice should shows hearing location, however when no location is selected, for example telephone or video the order should direct to make written application to CTSC/Local court in line with other orders.
Before SDO (CTSC address )
After SDO (Local Court)


### Testing branch and instruction ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
