### PR TITLE
CIV-9132 Refactor Solicitor OrgID

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/CreateApplicationTaskHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/CreateApplicationTaskHandler.java
@@ -31,6 +31,7 @@ import static uk.gov.hmcts.reform.civil.enums.CaseState.PENDING_APPLICATION_ISSU
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.civil.utils.OrgPolicyUtils.getRespondent2SolicitorOrgId;
 
 @RequiredArgsConstructor
 @Component
@@ -139,7 +140,7 @@ public class CreateApplicationTaskHandler implements BaseExternalTaskHandler {
                     if (generalApplication.getIsMultiParty().equals(YES) && caseData.getAddApplicant2().equals(NO)
                         && caseData.getRespondent2SameLegalRepresentative().equals(NO)
                         && generalApplication.getGeneralAppApplnSolicitor().getOrganisationIdentifier()
-                        .equals(caseData.getRespondent2OrganisationPolicy().getOrganisation().getOrganisationID())) {
+                        .equals(getRespondent2SolicitorOrgId(caseData))) {
 
                         GADetailsRespondentSol gaDetailsRespondentSolTwo = buildRespApplication(
                             generalApplication, caseData);

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -165,6 +165,8 @@ public class CaseData implements MappableObject {
     private final OrganisationPolicy applicant1OrganisationPolicy;
     private final OrganisationPolicy respondent1OrganisationPolicy;
     private final OrganisationPolicy respondent2OrganisationPolicy;
+    private final String respondent1OrganisationIDCopy;
+    private final String respondent2OrganisationIDCopy;
     private final YesOrNo respondent2SameLegalRepresentative;
     private final GAReferToJudgeGAspec referToJudge;
     private final GAReferToLegalAdvisorGAspec referToLegalAdvisor;
@@ -230,7 +232,6 @@ public class CaseData implements MappableObject {
     @Builder.Default
     private final List<Element<CaseDocument>> writtenRepConcurrentDocument = new ArrayList<>();
     private final BusinessProcess businessProcess;
-    private final String respondent1OrganisationIDCopy;
     private final GAOrderCourtOwnInitiativeGAspec orderCourtOwnInitiativeListForHearing;
     private final GAOrderWithoutNoticeGAspec orderWithoutNoticeListForHearing;
     private final GAOrderCourtOwnInitiativeGAspec orderCourtOwnInitiativeForWrittenRep;

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/SolicitorEmailValidation.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/SolicitorEmailValidation.java
@@ -14,6 +14,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.civil.utils.OrgPolicyUtils.getRespondent1SolicitorOrgId;
+import static uk.gov.hmcts.reform.civil.utils.OrgPolicyUtils.getRespondent2SolicitorOrgId;
 
 @Slf4j
 @Service
@@ -44,59 +46,43 @@ public class SolicitorEmailValidation {
                                                        CaseData civilCaseData, CaseData gaCaseData) {
 
         // civil claim applicant
-
         if (civilCaseData.getApplicant1OrganisationPolicy() != null
-            && checkIfOrgIdExists(civilCaseData.getApplicant1OrganisationPolicy())) {
-
-            if (checkIfOrgIdAndEmailAreSame(civilCaseData.getApplicant1OrganisationPolicy()
+            && checkIfOrgIdExists(civilCaseData.getApplicant1OrganisationPolicy())
+            && (checkIfOrgIdAndEmailAreSame(civilCaseData.getApplicant1OrganisationPolicy()
                                                 .getOrganisation().getOrganisationID(),
                                             civilCaseData.getApplicantSolicitor1UserDetails().getEmail(),
-                                            generalAppSolicitor)) {
+                                            generalAppSolicitor))) {
 
-                // Update GA Solicitor Email ID as same as Civil Claim claimant Solicitor Email
-                log.info("Update GA Solicitor Email ID as same as Civil Claim claimant Solicitor Email");
-                return updateSolDetails(civilCaseData.getApplicantSolicitor1UserDetails()
+            // Update GA Solicitor Email ID as same as Civil Claim claimant Solicitor Email
+            log.info("Update GA Solicitor Email ID as same as Civil Claim claimant Solicitor Email");
+            return updateSolDetails(civilCaseData.getApplicantSolicitor1UserDetails()
                                             .getEmail(), generalAppSolicitor);
 
-            }
         }
 
         // civil claim defendant 1
-
         if (civilCaseData.getRespondent1OrganisationPolicy() != null
-            && checkIfOrgIdExists(civilCaseData.getRespondent1OrganisationPolicy())) {
-
-            if (checkIfOrgIdAndEmailAreSame(civilCaseData.getRespondent1OrganisationPolicy()
-                                                .getOrganisation().getOrganisationID(),
+            && getRespondent1SolicitorOrgId(civilCaseData) != null
+            && (checkIfOrgIdAndEmailAreSame(getRespondent1SolicitorOrgId(civilCaseData),
                                             civilCaseData.getRespondentSolicitor1EmailAddress(),
-                                            generalAppSolicitor)) {
+                                            generalAppSolicitor))) {
 
-                log.info("Update GA Solicitor Email ID as same as Civil Claim Respondent Solicitor one Email");
-                return updateSolDetails(civilCaseData.getRespondentSolicitor1EmailAddress(), generalAppSolicitor);
+            log.info("Update GA Solicitor Email ID as same as Civil Claim Respondent Solicitor one Email");
+            return updateSolDetails(civilCaseData.getRespondentSolicitor1EmailAddress(), generalAppSolicitor);
 
-            }
         }
 
+        // civil claim defendant 2
         if (YES.equals(gaCaseData.getIsMultiParty())
-            && NO.equals(civilCaseData.getRespondent2SameLegalRepresentative())) {
+            && NO.equals(civilCaseData.getRespondent2SameLegalRepresentative())
+            && (getRespondent2SolicitorOrgId(civilCaseData) != null
+            && (checkIfOrgIdAndEmailAreSame(getRespondent2SolicitorOrgId(civilCaseData),
+                                            civilCaseData.getRespondentSolicitor2EmailAddress(),
+                                            generalAppSolicitor)))) {
 
-            // civil claim defendant 2
-
-            if (civilCaseData.getRespondent2OrganisationPolicy() != null
-                && checkIfOrgIdExists(civilCaseData.getRespondent2OrganisationPolicy())) {
-
-                if (checkIfOrgIdAndEmailAreSame(civilCaseData.getRespondent2OrganisationPolicy()
-                                                    .getOrganisation().getOrganisationID(),
-                                                civilCaseData.getRespondentSolicitor2EmailAddress(),
-                                                generalAppSolicitor)) {
-
-                    log.info("Update GA Solicitor Email ID as same as Civil Claim Respondent Solicitor Two Email");
-                    return updateSolDetails(civilCaseData.getRespondentSolicitor2EmailAddress(), generalAppSolicitor);
-
-                }
-            }
+            log.info("Update GA Solicitor Email ID as same as Civil Claim Respondent Solicitor Two Email");
+            return updateSolDetails(civilCaseData.getRespondentSolicitor2EmailAddress(), generalAppSolicitor);
         }
-
         return generalAppSolicitor;
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/OrgPolicyUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/OrgPolicyUtils.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+
+public class OrgPolicyUtils {
+
+    private OrgPolicyUtils() {
+        //NO-OP
+    }
+
+    public static String getRespondent1SolicitorOrgId(CaseData caseData) {
+        String orgId = getOrgId(caseData.getRespondent1OrganisationPolicy());
+        return orgId != null ? orgId : caseData.getRespondent1OrganisationIDCopy();
+    }
+
+    public static String getRespondent2SolicitorOrgId(CaseData caseData) {
+        String orgId = getOrgId(caseData.getRespondent2OrganisationPolicy());
+        return orgId != null ? orgId : caseData.getRespondent2OrganisationIDCopy();
+    }
+
+    private static String getOrgId(OrganisationPolicy orgPolicy) {
+        return orgPolicy != null
+            && orgPolicy.getOrganisation() != null
+            && orgPolicy.getOrganisation().getOrganisationID() != null
+            ? orgPolicy.getOrganisation().getOrganisationID() : null;
+    }
+}


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Screenshot attached for the Evidence of manual testing
- [ ] Functional, Smoke and API tests have been run locally
- [x] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-9132


### Change description ###
OrgID for the respondent solicitor are copied into respondent1OrganisationIDCopy and respondent2OrganisationIDCopy rather than storing it in respondent1OrganisationPolicy and respondent2OrganisationPolicy respectively in Civil Service. 

Refactor Respondent Solicitor OrgID to use respondent1OrganisationIDCopy and respondent2OrganisationIDCopy 


### Testing branch and instruction ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
