### PR TITLE
CIV-10100 Assisted Order for Applications change Order date heard

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,7 +9,7 @@ def type = "java"
 def product = "civil"
 def component = "general-applications"
 def camundaBranch = "master"
-def generalappCCDBranch = "master"
+def generalappCCDBranch = "CIV-10100"
 def ccddefbranch = "master"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandler.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.civil.model.genapplication.FreeFormOrderValues;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderCost;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderFurtherHearingDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderMadeDateHeardDetails;
+import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderDateHeard;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.DetailTextWithDate;
 import uk.gov.hmcts.reform.civil.service.GeneralAppLocationRefDataService;
 import uk.gov.hmcts.reform.civil.service.docmosis.finalorder.AssistedOrderFormGenerator;
@@ -52,6 +53,8 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
 
     private static final List<CaseEvent> EVENTS = Collections.singletonList(GENERATE_DIRECTIONS_ORDER);
     public static final String DATE_HEARD_VALIDATION = "The date entered cannot be in the future";
+
+    public static final String DATE_RANGE_NOT_ALLOWED = "The date range cannot have a 'from date' after the 'date to'";
     private final GeneralAppLocationRefDataService locationRefDataService;
 
     private static final String ON_INITIATIVE_SELECTION_TEST = "As this order was made on the court's own initiative "
@@ -160,7 +163,8 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
                                                      .date(LocalDate.now()).build());
 
         caseDataBuilder.assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder()
-                                                              .date(LocalDate.now()).build()).build();
+                                                              .singleDateSelection(AssistedOrderDateHeard.builder().singleDate(LocalDate.now()).build())
+                                                             .build()).build();
 
         LocalDate localDatePlus14days = LocalDate.now().plusDays(14);
         caseDataBuilder.claimantCostStandardBase(AssistedOrderCost.builder()
@@ -205,10 +209,22 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
         List<String> errors = new ArrayList<>();
         if (caseData.getAssistedOrderMadeSelection() != null
             && caseData.getAssistedOrderMadeSelection().equals(YesOrNo.YES)
-            && caseData.getAssistedOrderMadeDateHeardDetails().getDate().isAfter(LocalDate.now())) {
+            && Objects.nonNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection())
+            && caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate().isAfter(LocalDate.now())) {
             errors.add(DATE_HEARD_VALIDATION);
+        } else if (caseData.getAssistedOrderMadeSelection() != null
+            && caseData.getAssistedOrderMadeSelection().equals(YesOrNo.YES)
+            && Objects.nonNull(caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection())
+            && (caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeFrom().isAfter(LocalDate.now())
+            || caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeTo().isAfter(LocalDate.now()))) {
+            errors.add(DATE_HEARD_VALIDATION);
+        } else if (caseData.getAssistedOrderMadeSelection() != null
+            && caseData.getAssistedOrderMadeSelection().equals(YesOrNo.YES)
+            && Objects.nonNull(caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection())
+            && caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeFrom()
+            .isAfter(caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeTo())) {
+            errors.add(DATE_RANGE_NOT_ALLOWED);
         }
-
         return errors;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandler.java
@@ -54,7 +54,7 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
     private static final List<CaseEvent> EVENTS = Collections.singletonList(GENERATE_DIRECTIONS_ORDER);
     public static final String DATE_HEARD_VALIDATION = "The date entered cannot be in the future";
 
-    public static final String DATE_RANGE_NOT_ALLOWED = "The date range cannot have a 'from date' after the 'date to'";
+    public static final String DATE_RANGE_NOT_ALLOWED = "The date range in %s should not have a 'from date', that is after the 'date to'";
     private final GeneralAppLocationRefDataService locationRefDataService;
 
     private static final String ON_INITIATIVE_SELECTION_TEST = "As this order was made on the court's own initiative "
@@ -113,8 +113,8 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
 
     private CallbackResponse gaPopulateFinalOrderPreviewDoc(final CallbackParams callbackParams) {
         CaseData caseData = callbackParams.getCaseData();
-        List<String> errors = validAssistedOrderForm(caseData);
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
+        List<String> errors = validAssistedOrderForm(caseData);
         if (caseData.getFinalOrderSelection().equals(FREE_FORM_ORDER)) {
             CaseDocument freeform = gaFreeFormOrderGenerator.generate(
                     caseData,
@@ -223,9 +223,9 @@ public class JudicialFinalDecisionHandler extends CallbackHandler {
             && Objects.nonNull(caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection())
             && caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeFrom()
             .isAfter(caseData.getAssistedOrderMadeDateHeardDetails().getDateRangeSelection().getDateRangeTo())) {
-            errors.add(DATE_RANGE_NOT_ALLOWED);
+            errors.add(String.format(DATE_RANGE_NOT_ALLOWED, "Order Made"));
         }
-        return errors;
+        return  errors;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderDateHeard.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderDateHeard.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.civil.model.genapplication.finalorder;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,9 +17,8 @@ public class AssistedOrderDateHeard {
     private LocalDate dateRangeFrom;
     private LocalDate dateRangeTo;
 
-
     @JsonCreator
-    AssistedOrderDateHeard (@JsonProperty("singleDateHeard") LocalDate singleDate,
+    AssistedOrderDateHeard(@JsonProperty("singleDateHeard") LocalDate singleDate,
                             @JsonProperty("dateRangeFrom") LocalDate dateRangeFrom,
                             @JsonProperty("dateRangeTo") LocalDate dateRangeTo) {
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderDateHeard.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderDateHeard.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.civil.model.genapplication.finalorder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+public class AssistedOrderDateHeard {
+
+    private LocalDate singleDate;
+    private LocalDate dateRangeFrom;
+    private LocalDate dateRangeTo;
+
+
+    @JsonCreator
+    AssistedOrderDateHeard (@JsonProperty("singleDateHeard") LocalDate singleDate,
+                            @JsonProperty("dateRangeFrom") LocalDate dateRangeFrom,
+                            @JsonProperty("dateRangeTo") LocalDate dateRangeTo) {
+
+        this.singleDate = singleDate;
+        this.dateRangeFrom = dateRangeFrom;
+        this.dateRangeTo = dateRangeTo;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderMadeDateHeardDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderMadeDateHeardDetails.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Setter;
+import uk.gov.hmcts.reform.civil.enums.GAJudicialHearingType;
+import uk.gov.hmcts.reform.civil.enums.dq.LengthOfHearing;
+import uk.gov.hmcts.reform.civil.model.common.DynamicList;
+import uk.gov.hmcts.reform.civil.model.genapplication.HearingLength;
 
 import java.time.LocalDate;
 
@@ -13,10 +17,13 @@ import java.time.LocalDate;
 @Builder(toBuilder = true)
 public class AssistedOrderMadeDateHeardDetails {
 
-    private final LocalDate date;
-
+    private AssistedOrderDateHeard singleDateSelection;
+    private AssistedOrderDateHeard dateRangeSelection;
     @JsonCreator
-    AssistedOrderMadeDateHeardDetails(@JsonProperty("date") LocalDate date) {
-        this.date = date;
+    AssistedOrderMadeDateHeardDetails(@JsonProperty("singleDateSelection") AssistedOrderDateHeard singleDateSelection,
+                                       @JsonProperty("dateRangeSelection") AssistedOrderDateHeard dateRangeSelection) {
+
+        this.singleDateSelection = singleDateSelection;
+        this.dateRangeSelection = dateRangeSelection;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderMadeDateHeardDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/finalorder/AssistedOrderMadeDateHeardDetails.java
@@ -5,12 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Setter;
-import uk.gov.hmcts.reform.civil.enums.GAJudicialHearingType;
-import uk.gov.hmcts.reform.civil.enums.dq.LengthOfHearing;
-import uk.gov.hmcts.reform.civil.model.common.DynamicList;
-import uk.gov.hmcts.reform.civil.model.genapplication.HearingLength;
-
-import java.time.LocalDate;
 
 @Setter
 @Data
@@ -19,6 +13,7 @@ public class AssistedOrderMadeDateHeardDetails {
 
     private AssistedOrderDateHeard singleDateSelection;
     private AssistedOrderDateHeard dateRangeSelection;
+
     @JsonCreator
     AssistedOrderMadeDateHeardDetails(@JsonProperty("singleDateSelection") AssistedOrderDateHeard singleDateSelection,
                                        @JsonProperty("dateRangeSelection") AssistedOrderDateHeard dateRangeSelection) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
@@ -444,12 +444,11 @@ public class AssistedOrderFormGenerator implements TemplateDataGenerator<Assiste
     }
 
     protected String getOrderMadeDate(CaseData caseData) {
-
-        if (isNull(caseData.getAssistedOrderMadeDateHeardDetails())
-            || isNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection()) && isNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate())) {
-            return null;
+        if (nonNull(caseData.getAssistedOrderMadeDateHeardDetails())
+            && nonNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection())) {
+            return getDateFormatted(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate());
         }
-        return getDateFormatted(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate());
+        return null;
     }
 
     protected String getReasonText(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
@@ -446,10 +446,10 @@ public class AssistedOrderFormGenerator implements TemplateDataGenerator<Assiste
     protected String getOrderMadeDate(CaseData caseData) {
 
         if (isNull(caseData.getAssistedOrderMadeDateHeardDetails())
-            || isNull(caseData.getAssistedOrderMadeDateHeardDetails().getDate())) {
+            || isNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection()) && isNull(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate())) {
             return null;
         }
-        return getDateFormatted(caseData.getAssistedOrderMadeDateHeardDetails().getDate());
+        return getDateFormatted(caseData.getAssistedOrderMadeDateHeardDetails().getSingleDateSelection().getSingleDate());
     }
 
     protected String getReasonText(CaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandlerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.LocationRefData;
 import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.Document;
+import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderDateHeard;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderMadeDateHeardDetails;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.GeneralAppLocationRefDataService;
@@ -125,8 +126,8 @@ class JudicialFinalDecisionHandlerTest extends BaseCallbackHandlerTest {
             .isEqualTo(ON_INITIATIVE_SELECTION_TEST);
         assertThat(response.getData()).extracting("orderMadeOnWithOutNotice").extracting("detailText")
             .isEqualTo(WITHOUT_NOTICE_SELECTION_TEXT);
-        assertThat(response.getData()).extracting("assistedOrderMadeDateHeardDetails").extracting("date")
-            .isEqualTo(LocalDate.now().toString());
+        assertThat(response.getData()).extracting("assistedOrderMadeDateHeardDetails").extracting("singleDateSelection")
+            .isNotNull();
 
         LocalDate localDatePlus14days = LocalDate.now().plusDays(14);
         assertThat(response.getData()).extracting("claimantCostStandardBase").extracting("costPaymentDeadLine")
@@ -159,8 +160,8 @@ class JudicialFinalDecisionHandlerTest extends BaseCallbackHandlerTest {
             .finalOrderSelection(FinalOrderSelection.FREE_FORM_ORDER)
             .generalAppDetailsOfOrder("order test")
             .assistedOrderMadeSelection(YesOrNo.YES)
-            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder()
-                                                   .date(LocalDate.now().plusDays(1)).build())
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().singleDateSelection(
+                    AssistedOrderDateHeard.builder().singleDate(LocalDate.now().plusDays(1)).build()).build())
             .build();
         CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
         // When
@@ -182,8 +183,8 @@ class JudicialFinalDecisionHandlerTest extends BaseCallbackHandlerTest {
             .finalOrderSelection(FinalOrderSelection.FREE_FORM_ORDER)
             .generalAppDetailsOfOrder("order test")
             .assistedOrderMadeSelection(YesOrNo.YES)
-            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder()
-                                                   .date(LocalDate.now()).build())
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().singleDateSelection(
+                AssistedOrderDateHeard.builder().singleDate(LocalDate.now()).build()).build())
             .build();
         CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
         // When
@@ -205,8 +206,8 @@ class JudicialFinalDecisionHandlerTest extends BaseCallbackHandlerTest {
             .finalOrderSelection(FinalOrderSelection.FREE_FORM_ORDER)
             .generalAppDetailsOfOrder("order test")
             .assistedOrderMadeSelection(YesOrNo.NO)
-            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder()
-                                                   .date(LocalDate.now()).build())
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().singleDateSelection(
+                AssistedOrderDateHeard.builder().singleDate(LocalDate.now()).build()).build())
             .build();
         CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
         // When

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudicialFinalDecisionHandlerTest.java
@@ -195,6 +195,122 @@ class JudicialFinalDecisionHandlerTest extends BaseCallbackHandlerTest {
     }
 
     @Test
+    void shouldNotShowError_When_OrderDateIsSingleSelection() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().singleDateSelection(
+                AssistedOrderDateHeard.builder().singleDate(LocalDate.now()).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        CaseData updatedData = objMapper.convertValue(response.getData(), CaseData.class);
+        assertThat(updatedData.getGaFinalOrderDocPreview()).isNotNull();
+
+    }
+
+    @Test
+    void shouldShowError_When_OrderDateIsSingleSelectionAfterTodayDate() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().singleDateSelection(
+                AssistedOrderDateHeard.builder().singleDate(LocalDate.now().plusDays(1)).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response.getErrors()).isNotNull();
+
+    }
+
+    @Test
+    void shouldNotShowError_When_OrderDateIsDateRange_FromIsAfter() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().dateRangeSelection(
+                AssistedOrderDateHeard.builder().dateRangeFrom(LocalDate.now().plusDays(1))
+                    .dateRangeTo(LocalDate.now()).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response.getErrors()).isNotNull();
+
+    }
+
+    @Test
+    void shouldNotShowError_When_OrderDateIsDateRange_ToIsAfter() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().dateRangeSelection(
+                AssistedOrderDateHeard.builder().dateRangeFrom(LocalDate.now())
+                    .dateRangeTo(LocalDate.now().plusDays(1)).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response.getErrors()).isNotNull();
+    }
+
+    @Test
+    void shouldShowError_When_OrderDateIsDateRange_FromIsAfterDateTo() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().dateRangeSelection(
+                AssistedOrderDateHeard.builder().dateRangeFrom(LocalDate.now().minusDays(2))
+                    .dateRangeTo(LocalDate.now().minusDays(3)).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response.getErrors()).isNotNull();
+    }
+
+    @Test
+    void shouldNotShowError_When_OrderDateIsDateRange_FromIsAfterDateTo() {
+
+        when(assistedOrderFormGenerator.generate(any(), any()))
+            .thenReturn(CaseDocument.builder().documentLink(Document.builder().build()).build());
+        CaseData caseData = CaseDataBuilder.builder().generalOrderApplication()
+            .build()
+            .toBuilder().finalOrderSelection(FinalOrderSelection.ASSISTED_ORDER)
+            .generalAppDetailsOfOrder("order test")
+            .assistedOrderMadeSelection(YesOrNo.YES)
+            .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().dateRangeSelection(
+                AssistedOrderDateHeard.builder().dateRangeFrom(LocalDate.now().minusDays(2))
+                    .dateRangeTo(LocalDate.now()).build()).build()).build();
+        CallbackParams params = callbackParamsOf(caseData, MID, "populate-final-order-preview-doc");
+
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        assertThat(response.getErrors()).isEmpty();
+    }
+
+    @Test
     void shouldNotShowError_When_AssistedOrderNotMade_FinalOrderPreviewDoc_onMidEventCallback() {
 
         // Given

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGeneratorTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
 import uk.gov.hmcts.reform.civil.model.genapplication.HearingLength;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderAppealDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderCost;
+import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderDateHeard;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderFurtherHearingDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderGiveReasonsDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.finalorder.AssistedOrderHeardRepresentation;
@@ -55,6 +56,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -844,7 +846,9 @@ class AssistedOrderFormGeneratorTest {
             CaseData caseData = CaseData.builder()
                 .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails
                                                        .builder()
-                                                       .date(LocalDate.now())
+                                                       .singleDateSelection(AssistedOrderDateHeard
+                                                                                .builder().singleDate(LocalDate.now())
+                                                                                .build())
                                                        .build())
                 .build();
             String assistedOrderString = generator.getOrderMadeDate(caseData);
@@ -860,7 +864,7 @@ class AssistedOrderFormGeneratorTest {
             CaseData caseData = CaseData.builder()
                 .assistedOrderGiveReasonsYesNo(null)
                 .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
+            String assistedOrderString = generator.getReasonText(caseData);
             assertNull(assistedOrderString);
         }
 
@@ -869,7 +873,7 @@ class AssistedOrderFormGeneratorTest {
             CaseData caseData = CaseData.builder()
                 .assistedOrderGiveReasonsYesNo(YesOrNo.NO)
                 .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
+            String assistedOrderString = generator.getReasonText(caseData);
             assertNull(assistedOrderString);
         }
 
@@ -879,7 +883,7 @@ class AssistedOrderFormGeneratorTest {
                 .assistedOrderGiveReasonsYesNo(YesOrNo.YES)
                 .assistedOrderGiveReasonsDetails(AssistedOrderGiveReasonsDetails.builder().build())
                 .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
+            String assistedOrderString = generator.getReasonText(caseData);
             assertNull(assistedOrderString);
         }
 
@@ -892,28 +896,20 @@ class AssistedOrderFormGeneratorTest {
                                                      .reasonsText(TEST_TEXT)
                                                      .build())
                 .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
-            assertNull(assistedOrderString);
-        }
-
-        @Test
-        void shouldReturnNull_When_OrderMadeHeard_Date_Null() {
-            CaseData caseData = CaseData.builder()
-                .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails.builder().build())
-                .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
-            assertNull(assistedOrderString);
+            String assistedOrderString = generator.getReasonText(caseData);
+            assertNotNull(assistedOrderString);
         }
 
         @Test
         void shouldReturnText_When_OrderMadeHeard() {
             CaseData caseData = CaseData.builder()
                 .assistedOrderMadeDateHeardDetails(AssistedOrderMadeDateHeardDetails
-                                                       .builder()
-                                                       .date(LocalDate.now())
+                                                       .builder().singleDateSelection(AssistedOrderDateHeard.builder()
+                                                                                          .singleDate(LocalDate.now()).build())
                                                        .build())
                 .build();
-            String assistedOrderString = generator.getOrderMadeDate(caseData);
+            String assistedOrderString = generator.getDateFormatted(caseData.getAssistedOrderMadeDateHeardDetails()
+                                                                        .getSingleDateSelection().getSingleDate());
             assertThat(assistedOrderString).contains(DateFormatHelper
                                                          .formatLocalDate(LocalDate.now(), " d MMMM yyyy"));
         }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [x ] Screenshot attached for the Evidence of manual testing
- [ x] Functional, Smoke and API tests have been run locally
- [x ] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-10100

### Change description ###

Task - Section "Order Made"

In the previous design this section was 2 radio buttons with the "Yes" Option hiding a Date box, this has now been updated. Now when the option "Yes" is selected it will open up numerous more options listed below

The new 3 options will be displayed when the option "yes" is selected these will per the above screenshot (Single Date, Date Range, Bespoke Range)

When the option is selected is "Single Date" the below will be displayed (Where xx xx xxxx is in the date range this should be todays date but update able but only to a date in the past. Future dates should give an error)

When the option is selected is "Date Range" the below will be displayed (The date range boxes will not be pre-populated, Users can only enter dates in the past, Entry box 1 most contain the oldest date)

When the option is selected is "Bespoke Range" the below will be displayed (No restriction to character type or length of entry)

### Testing branch and instruction ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
