### PR TITLE
CIV-12040 Defendant 2 is the Applicant - Other Parties can't see application to respond - Bug fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/ParentCaseUpdateHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/ParentCaseUpdateHelper.java
@@ -307,7 +307,7 @@ public class ParentCaseUpdateHelper {
             } else {
                 if (generalAppCaseData.getIsMultiParty().equals(NO)) {
                     updateJudgeOrClaimantFromRespCollection(generalAppCaseData, applicationId, gaClaimantDetails, gaDetailsRespondentSol);
-                } else if (generalAppCaseData.getIsMultiParty().equals(YES) && gaDetailsRespondentSol.isEmpty()) {
+                } else if (generalAppCaseData.getIsMultiParty().equals(YES) && gaDetailsRespondentSol.isEmpty() && !gaDetailsRespondentSol2.isEmpty()) {
                     updateJudgeOrClaimantFromRespCollection(generalAppCaseData, applicationId, gaClaimantDetails, gaDetailsRespondentSol2);
                     updateRespCollectionForMultiParty(generalAppCaseData, applicationId, gaDetailsRespondentSol, gaDetailsRespondentSol2);
                 } else {


### PR DESCRIPTION

**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)
- [ x] Screenshot attached for the Evidence of manual testing
- [ x] Functional, Smoke and API tests have been run locally
- [ x] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-12040

### Change description ###

In a multiparty case where Defendant 2 makes an application, with notice, the application is made and appears to Defendant 2 in state awaiting respondent response but Claimant and Defendant 1 cannot see the application when logged in

Example - 1703-2363-9622-6100


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
