### PR TITLE
CIV-12949 Respondents should able to respond to application once 1V2 different solicitor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToApplicationHandler.java
@@ -78,7 +78,6 @@ public class RespondToApplicationHandler extends CallbackHandler {
     private final CaseDetailsConverter caseDetailsConverter;
     private final IdamClient idamClient;
     private final GeneralAppLocationRefDataService locationRefDataService;
-    private UserInfo userInfo;
     private final CoreCaseDataService coreCaseDataService;
 
     private static final String RESPONSE_MESSAGE = "# You have provided the requested information";
@@ -117,14 +116,6 @@ public class RespondToApplicationHandler extends CallbackHandler {
             callbackKey(ABOUT_TO_SUBMIT), this::submitClaim,
             callbackKey(SUBMITTED), this::buildResponseConfirmation
         );
-    }
-
-    public UserInfo getUserInfo(String token) {
-
-        if (Objects.isNull(userInfo)) {
-            return idamClient.getUserInfo(token);
-        }
-        return userInfo;
     }
 
     private AboutToStartOrSubmitCallbackResponse applicationValidation(CallbackParams callbackParams) {
@@ -189,7 +180,8 @@ public class RespondToApplicationHandler extends CallbackHandler {
 
     public List<String> applicationExistsValidation(CallbackParams callbackParams) {
         CaseData caseData = callbackParams.getCaseData();
-        userInfo = getUserInfo(callbackParams.getParams().get(BEARER_TOKEN).toString());
+        UserInfo userInfo = idamClient.getUserInfo(callbackParams.getParams().get(BEARER_TOKEN).toString());
+
         List<Element<GARespondentResponse>> respondentResponse = caseData.getRespondentsResponses();
 
         List<String> errors = new ArrayList<>();
@@ -301,7 +293,7 @@ public class RespondToApplicationHandler extends CallbackHandler {
         CaseData caseData = caseDetailsConverter.toCaseData(callbackParams.getRequest().getCaseDetails());
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
 
-        userInfo = getUserInfo(callbackParams.getParams().get(BEARER_TOKEN).toString());
+        UserInfo userInfo = idamClient.getUserInfo(callbackParams.getParams().get(BEARER_TOKEN).toString());
 
         List<Element<GARespondentResponse>> respondentsResponses =
             addResponse(buildResponse(caseData, userInfo), caseData.getRespondentsResponses());
@@ -317,8 +309,6 @@ public class RespondToApplicationHandler extends CallbackHandler {
         caseDataBuilder.generalAppRespondConsentDocument(null);
         caseDataBuilder.generalAppRespondDebtorDocument(null);
         caseDataBuilder.businessProcess(BusinessProcess.ready(RESPOND_TO_APPLICATION)).build();
-
-        userInfo = null;
 
         CaseData updatedCaseData = caseDataBuilder.build();
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Screenshot attached for the Evidence of manual testing
- [ ] Functional, Smoke and API tests have been run locally
- [ ] Full gradle build and run tests with coverage have been completed (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-12949


### Change description ###
Scenario : 

 1 v 2 Different solicitor: After one of the respondent responded to application, other respondent should able to respond again.

Remove singleton method as it caches the respondent info and use it to compare when other respondent trying to respond application which result in error message

### Testing branch and instruction ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
