### PR TITLE
CIV-13860 Change courtname to use externalShortName field in docs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/LocationRefData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/LocationRefData.java
@@ -12,6 +12,7 @@ public class LocationRefData {
     private String courtVenueId;
     private String epimmsId;
     private String siteName;
+    private String externalShortName;
     private String regionId;
     private String region;
     private String courtType;
@@ -30,6 +31,7 @@ public class LocationRefData {
     LocationRefData(@JsonProperty("court_venue_id") String courtVenueId,
                     @JsonProperty("epimms_id") String epimmsId,
                     @JsonProperty("site_name") String siteName,
+                    @JsonProperty("external_short_name") String externalShortName,
                     @JsonProperty("region_id") String regionId,
                     @JsonProperty("region") String region,
                     @JsonProperty("court_type") String courtType,
@@ -46,6 +48,7 @@ public class LocationRefData {
         this.courtVenueId = courtVenueId;
         this.epimmsId = epimmsId;
         this.siteName = siteName;
+        this.externalShortName = externalShortName;
         this.regionId = regionId;
         this.region = region;
         this.courtType = courtType;

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/consentorder/ConsentOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/consentorder/ConsentOrderGenerator.java
@@ -42,7 +42,7 @@ public class ConsentOrderGenerator implements TemplateDataGenerator<ConsentOrder
                 .defendant1Name(caseData.getDefendant1PartyName())
                 .defendant2Name(caseData.getDefendant2PartyName() != null ? caseData.getDefendant2PartyName() : null)
                 .orderDate(LocalDate.now())
-                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .siteName(caseData.getCaseManagementLocation().getSiteName())
                 .address(caseData.getCaseManagementLocation().getAddress())
                 .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGenerator.java
@@ -65,7 +65,7 @@ public class DirectionOrderGenerator implements TemplateDataGenerator<JudgeDecis
                 .claimant2Name(caseData.getClaimant2PartyName() != null ? caseData.getClaimant2PartyName() : null)
                 .defendant1Name(caseData.getDefendant1PartyName())
                 .defendant2Name(caseData.getDefendant2PartyName() != null ? caseData.getDefendant2PartyName() : null)
-                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .siteName(caseData.getCaseManagementLocation().getSiteName())
                 .address(caseData.getCaseManagementLocation().getAddress())
                 .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGenerator.java
@@ -64,7 +64,7 @@ public class DismissalOrderGenerator implements TemplateDataGenerator<JudgeDecis
                 .claimant2Name(caseData.getClaimant2PartyName() != null ? caseData.getClaimant2PartyName() : null)
                 .defendant1Name(caseData.getDefendant1PartyName())
                 .defendant2Name(caseData.getDefendant2PartyName() != null ? caseData.getDefendant2PartyName() : null)
-                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .siteName(caseData.getCaseManagementLocation().getSiteName())
                 .address(caseData.getCaseManagementLocation().getAddress())
                 .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGenerator.java
@@ -78,7 +78,7 @@ public class AssistedOrderFormGenerator implements TemplateDataGenerator<Assiste
                 .defendant2Name(caseData
                                     .getIsMultiParty().equals(YesOrNo.YES) ? caseData.getDefendant2PartyName() : null)
                 .courtLocation(docmosisService
-                                   .getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                                   .getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .siteName(caseData.getCaseManagementLocation().getSiteName())
                 .address(caseData.getCaseManagementLocation().getAddress())
                 .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/FreeFormOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/FreeFormOrderGenerator.java
@@ -61,7 +61,7 @@ public class FreeFormOrderGenerator implements TemplateDataGenerator<FreeFormOrd
             .freeFormRecitalText(caseData.getFreeFormRecitalText())
             .freeFormOrderedText(caseData.getFreeFormOrderedText())
             .freeFormOrderValue(getFreeFormOrderValue(caseData))
-            .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+            .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
             .siteName(caseData.getCaseManagementLocation().getSiteName())
             .address(caseData.getCaseManagementLocation().getAddress())
             .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGenerator.java
@@ -72,7 +72,7 @@ public class GeneralOrderGenerator implements TemplateDataGenerator<JudgeDecisio
                 .defendant1Name(caseData.getDefendant1PartyName())
                 .defendant2Name(caseData.getDefendant2PartyName() != null ? caseData.getDefendant2PartyName() : null)
                 .claimNumber(caseData.getCcdCaseReference().toString())
-                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .siteName(caseData.getCaseManagementLocation().getSiteName())
                 .address(caseData.getCaseManagementLocation().getAddress())
                 .postcode(caseData.getCaseManagementLocation().getPostcode())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingFormGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingFormGenerator.java
@@ -74,7 +74,7 @@ public class HearingFormGenerator implements TemplateDataGenerator<HearingForm> 
                 && nonNull(caseData.getDefendant2PartyName());
 
         return HearingForm.builder()
-            .court(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+            .court(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
             .judgeHearingLocation(caseData.getGaHearingNoticeDetail().getHearingLocation().getValue().getLabel())
             .caseNumber(getCaseNumberFormatted(caseData))
             .creationDate(getDateFormatted(LocalDate.now()))

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGenerator.java
@@ -75,7 +75,7 @@ public class HearingOrderGenerator implements TemplateDataGenerator<JudgeDecisio
                 .estimatedHearingLength(caseData.getJudicialListForHearing()
                                             .getJudicialTimeEstimate().getDisplayedValue())
                 .submittedOn(LocalDate.now())
-                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getVenueName())
+                .courtName(docmosisService.getCaseManagementLocationVenueName(caseData, authorisation).getExternalShortName())
                 .judgeHearingLocation(caseData.getJudicialListForHearing()
                                           .getHearingPreferencesPreferredType() == GAJudicialHearingType.IN_PERSON
                                           ? caseData.getJudicialListForHearing()

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/consentorder/ConsentOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/consentorder/ConsentOrderGeneratorTest.java
@@ -87,7 +87,7 @@ class ConsentOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(CONSENT_ORDER_FORM)))
             .thenReturn(new DocmosisDocument(CONSENT_ORDER_FORM.getDocumentTitle(), bytes));
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         consentOrderGenerator.generate(caseData, BEARER_TOKEN);
 
         verify(documentManagementService).uploadDocument(
@@ -103,7 +103,7 @@ class ConsentOrderGeneratorTest {
         CaseData caseData = CaseDataBuilder.builder().consentOrderApplication().build().toBuilder().isMultiParty(YES)
             .build();
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         var templateData = consentOrderGenerator.getTemplateData(caseData, "auth");
         assertThatFieldsAreCorrect_GeneralOrder(templateData, caseData);
     }
@@ -132,7 +132,7 @@ class ConsentOrderGeneratorTest {
             .isMultiParty(NO)
             .build();
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
         var templateData = consentOrderGenerator.getTemplateData(caseData, "auth");
         assertThatFieldsAreCorrect_GeneralOrder_1v1(templateData, caseData);
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/directionorder/DirectionOrderGeneratorTest.java
@@ -75,9 +75,9 @@ class DirectionOrderGeneratorTest {
     private GeneralAppLocationRefDataService generalAppLocationRefDataService;
 
     private static List<LocationRefData> locationRefData = Arrays
-        .asList(LocationRefData.builder().epimmsId("1").venueName("Reading").build(),
-                LocationRefData.builder().epimmsId("2").venueName("London").build(),
-                LocationRefData.builder().epimmsId("3").venueName("Manchester").build());
+        .asList(LocationRefData.builder().epimmsId("1").externalShortName("Reading").build(),
+                LocationRefData.builder().epimmsId("2").externalShortName("London").build(),
+                LocationRefData.builder().epimmsId("3").externalShortName("Manchester").build());
 
     @BeforeEach
     public void setUp() {
@@ -91,7 +91,7 @@ class DirectionOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(DIRECTION_ORDER)))
             .thenReturn(new DocmosisDocument(DIRECTION_ORDER.getDocumentTitle(), bytes));
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         CaseData caseData = CaseDataBuilder.builder().directionOrderApplication().build();
 
         directionOrderGenerator.generate(caseData, BEARER_TOKEN);
@@ -138,7 +138,7 @@ class DirectionOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = directionOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -185,7 +185,7 @@ class DirectionOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
 
             var templateData = directionOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -234,7 +234,7 @@ class DirectionOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcdef ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
 
             var templateData = directionOrderGenerator.getTemplateData(updateCaseData, "auth");
 
@@ -292,7 +292,7 @@ class DirectionOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn(StringUtils.EMPTY);
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = directionOrderGenerator.getTemplateData(updateCaseData, "auth");
 
@@ -343,7 +343,7 @@ class DirectionOrderGeneratorTest {
 
             when(docmosisService.populateJudgeReason(any())).thenReturn(StringUtils.EMPTY);
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
             var templateData = directionOrderGenerator.getTemplateData(updateCaseData, "auth");
 
             assertNull(templateData.getJudgeRecital());

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dismissalorder/DismissalOrderGeneratorTest.java
@@ -73,7 +73,7 @@ class DismissalOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(DISMISSAL_ORDER)))
             .thenReturn(new DocmosisDocument(DISMISSAL_ORDER.getDocumentTitle(), bytes));
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         CaseData caseData = CaseDataBuilder.builder().dismissalOrderApplication().build();
 
         dismissalOrderGenerator.generate(caseData, BEARER_TOKEN);
@@ -119,7 +119,7 @@ class DismissalOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = dismissalOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -159,7 +159,7 @@ class DismissalOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
 
             var templateData = dismissalOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -213,7 +213,7 @@ class DismissalOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcdef ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
 
             var templateData = dismissalOrderGenerator.getTemplateData(updateData, "auth");
 
@@ -263,7 +263,7 @@ class DismissalOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn(StringUtils.EMPTY);
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = dismissalOrderGenerator.getTemplateData(updateData, "auth");
 
@@ -308,7 +308,7 @@ class DismissalOrderGeneratorTest {
             when(docmosisService.reasonAvailable(any())).thenReturn(YesOrNo.NO);
             when(docmosisService.populateJudgeReason(any())).thenReturn("");
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = dismissalOrderGenerator.getTemplateData(updateData, "auth");
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/AssistedOrderFormGeneratorTest.java
@@ -2098,7 +2098,10 @@ class AssistedOrderFormGeneratorTest {
     @Test
     void shouldGenerateAssistedOrderDocument() {
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+            .thenReturn(LocationRefData.builder()
+                            .epimmsId("2")
+                            .externalShortName("Reading")
+                            .build());
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(ASSISTED_ORDER_FORM)))
             .thenReturn(new DocmosisDocument(ASSISTED_ORDER_FORM.getDocumentTitle(), bytes));
 
@@ -2138,7 +2141,10 @@ class AssistedOrderFormGeneratorTest {
             .thenReturn(new DocmosisDocument(ASSISTED_ORDER_FORM.getDocumentTitle(), bytes));
 
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder()
+                            .epimmsId("2")
+                            .externalShortName("London")
+                            .build());
         CaseData caseData = getSampleGeneralApplicationCaseData(YES).toBuilder()
             .caseManagementLocation(GACaseLocation.builder().siteName("testing")
                                         .address("london court")

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/FreeFormOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/finalorder/FreeFormOrderGeneratorTest.java
@@ -182,7 +182,10 @@ class FreeFormOrderGeneratorTest {
             .finalOrderFreeForm().isMultiParty(YES).build().toBuilder()
             .build();
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder()
+                            .epimmsId("2")
+                            .externalShortName("London")
+                            .build());
         FreeFormOrder templateDate = generator.getTemplateData(caseData, "auth");
         assertThatFieldsAreCorrect_FreeFormOrder(templateDate, caseData);
     }
@@ -212,7 +215,10 @@ class FreeFormOrderGeneratorTest {
             .build();
 
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+            .thenReturn(LocationRefData.builder()
+                            .epimmsId("2")
+                            .externalShortName("Manchester")
+                            .build());
         FreeFormOrder templateDate = generator.getTemplateData(caseData, "auth");
         assertThatFieldsAreCorrect_FreeFormOrder_1V1(templateDate, caseData);
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/generalorder/GeneralOrderGeneratorTest.java
@@ -75,7 +75,7 @@ class GeneralOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(GENERAL_ORDER)))
             .thenReturn(new DocmosisDocument(GENERAL_ORDER.getDocumentTitle(), bytes));
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         CaseData caseData = CaseDataBuilder.builder().generalOrderApplication().build();
         generalOrderGenerator.generate(caseData, BEARER_TOKEN);
 
@@ -119,7 +119,7 @@ class GeneralOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
 
             var templateData = generalOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -164,7 +164,7 @@ class GeneralOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcd ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
 
             var templateData = generalOrderGenerator.getTemplateData(caseData, "auth");
 
@@ -211,7 +211,7 @@ class GeneralOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn("abcdef ".concat(LocalDate.now().format(DATE_FORMATTER)));
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
 
             var templateData = generalOrderGenerator.getTemplateData(updateData, "auth");
 
@@ -269,7 +269,7 @@ class GeneralOrderGeneratorTest {
             when(docmosisService.populateJudicialByCourtsInitiative(any()))
                 .thenReturn(StringUtils.EMPTY);
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
 
             var templateData = generalOrderGenerator.getTemplateData(updateData, "auth");
 
@@ -320,7 +320,7 @@ class GeneralOrderGeneratorTest {
 
             when(docmosisService.populateJudgeReason(any())).thenReturn(StringUtils.EMPTY);
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
 
             var templateData = generalOrderGenerator.getTemplateData(updateData, "auth");
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingFormGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingFormGeneratorTest.java
@@ -133,7 +133,7 @@ class HearingFormGeneratorTest {
                  .uploadDocument(any(), any()))
             .thenReturn(CASE_DOCUMENT);
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
 
         Map<String, String> refMap = new HashMap<>();
         refMap.put("applicantSolicitor1Reference", "app1ref");

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearingorder/HearingOrderGeneratorTest.java
@@ -72,7 +72,7 @@ class HearingOrderGeneratorTest {
         when(documentGeneratorService.generateDocmosisDocument(any(MappableObject.class), eq(HEARING_ORDER)))
             .thenReturn(new DocmosisDocument(HEARING_ORDER.getDocumentTitle(), bytes));
         when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-            .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+            .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
         CaseData caseData = CaseDataBuilder.builder().hearingOrderApplication(YesOrNo.NO, YesOrNo.NO).build();
 
         hearingOrderGenerator.generate(caseData, BEARER_TOKEN);
@@ -112,7 +112,7 @@ class HearingOrderGeneratorTest {
         @Test
         void whenJudgeMakeDecision_ShouldGetHearingOrderData() {
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
             CaseData caseData = CaseDataBuilder.builder()
                 .hearingOrderApplication(YesOrNo.NO, YesOrNo.YES).build().toBuilder()
                 .isMultiParty(YES)
@@ -154,7 +154,7 @@ class HearingOrderGeneratorTest {
         @Test
         void whenJudgeMakeDecision_ShouldGetHearingOrderData_Option2() {
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Manchester").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Manchester").build());
             CaseData caseData = CaseDataBuilder.builder()
                 .hearingOrderApplication(YesOrNo.NO, YesOrNo.YES).build().toBuilder()
                 .isMultiParty(NO)
@@ -208,7 +208,7 @@ class HearingOrderGeneratorTest {
         @Test
         void whenJudgeMakeDecision_ShouldGetHearingOrderData_Option3() {
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("London").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("London").build());
             CaseData caseData = CaseDataBuilder.builder()
                 .hearingOrderApplication(YesOrNo.NO, YesOrNo.YES).build().toBuilder()
                 .isMultiParty(NO)
@@ -253,7 +253,7 @@ class HearingOrderGeneratorTest {
         @Test
         void whenJudgeMakeDecision_ShouldGetHearingOrderData_Option3_1v1() {
             when(docmosisService.getCaseManagementLocationVenueName(any(), any()))
-                .thenReturn(LocationRefData.builder().epimmsId("2").venueName("Reading").build());
+                .thenReturn(LocationRefData.builder().epimmsId("2").externalShortName("Reading").build());
             CaseData caseData = CaseDataBuilder.builder()
                 .hearingOrderApplication(YesOrNo.NO, YesOrNo.YES).build().toBuilder()
                 .isMultiParty(YES)


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-13860

- Changed populating order/hearing templates to use externalShortName field from location refdata for courtname


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
