### PR TITLE
CIV-16762 remove non-required minti toggle

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserCallbackHandler.java
@@ -156,9 +156,7 @@ public class AssignCaseToUserCallbackHandler extends CallbackHandler {
 
             }
 
-            if (featureToggleService.isMultiOrIntermediateTrackEnabled()) {
-                rolesAndAccessAssignmentService.copyAllocatedRolesFromRolesAndAccess(caseData.getGeneralAppParentCaseLink().getCaseReference(), caseId);
-            }
+            rolesAndAccessAssignmentService.copyAllocatedRolesFromRolesAndAccess(caseData.getGeneralAppParentCaseLink().getCaseReference(), caseId);
 
             return AboutToStartOrSubmitCallbackResponse.builder().data(caseDataBuilder.build().toMap(mapper)).errors(
                     errors)

--- a/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleService.java
@@ -8,8 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Slf4j
 @Service
@@ -76,10 +74,4 @@ public class FeatureToggleService {
         return internalClient.boolVariation(feature, createLDUser().custom("timestamp", date).build(), defaultValue);
     }
 
-    public boolean isMultiOrIntermediateTrackEnabled() {
-        ZoneId zoneId = ZoneId.systemDefault();
-        long epoch;
-        epoch = LocalDateTime.now().atZone(zoneId).toEpochSecond();
-        return isFeatureEnabledForDate("multi-or-intermediate-track", epoch, false);
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleServiceTest.java
@@ -15,8 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,19 +140,6 @@ class FeatureToggleServiceTest {
         assertThat(capturedLdUser.getKey()).isEqualTo("civil-service");
         assertThat(ImmutableList.copyOf(capturedLdUser.getCustomAttributes())).extracting("name")
             .containsOnlyOnceElementsOf(customAttributesKeys);
-    }
-
-    @Test
-    void shouldReturnFalse_whenFeatureIsDisabled() {
-        String featureKey = "multi-or-intermediate-track";
-        ZoneId zoneId = ZoneId.systemDefault();
-        long epoch = LocalDateTime.now().atZone(zoneId).toEpochSecond();
-
-        when(featureToggleService.isFeatureEnabledForDate(eq(featureKey), eq(epoch), eq(false)))
-            .thenReturn(false);
-
-        boolean result = featureToggleService.isMultiOrIntermediateTrackEnabled();
-        assertThat(result).isFalse();
     }
 
 }


### PR DESCRIPTION
Post live, no longer require multi-or-intermediate-track toggle when determining if case roles should be copied




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
